### PR TITLE
Fix version check if in-kernel modinfo is missing 'version:' tag

### DIFF
--- a/dkms
+++ b/dkms
@@ -709,6 +709,7 @@ read_conf()
 get_module_verinfo(){
     unset res
     local vals=
+    res[0]=0 #if "version:" tag is missing, assume it is 0
     while read -a vals; do
     case ${vals[0]} in
         version:)


### PR DESCRIPTION
- Some kernel modules (openvswitch.ko) do not have a 'version:' tag.
  In this case get_module_verinfo() returns res[0] empty.
  check_version_sanity() flattens the array promoting the
  'srcversion:' tag to the primary version.
- This means that if a module with a version tries to replace a
  module without a version, --force is needed. This is not ideal.
- This patch assures that a version is always present in the array.
  If the tag is missing, the version is set to '0'.
