### PR TITLE
invoke_command: Avoid leaking a sleep process

### DIFF
--- a/dkms
+++ b/dkms
@@ -72,10 +72,18 @@ invoke_command()
     if [[ $3 = background && ! $verbose ]]; then
         local pid progresspid
         (eval "$1" >/dev/null 2>&1) & pid=$!
-        while [ -d /proc/$pid ]; do
-            sleep 3
-            echo -en "."
-        done & progresspid=$!
+        {
+            on_exit() {
+                kill $(jobs -p) 2>/dev/null
+                wait $(jobs -p) 2>/dev/null
+            }
+            trap on_exit EXIT
+            while [ -d /proc/$pid ]; do
+                sleep 3 &
+                wait $!
+                echo -en "."
+            done
+        } & progresspid=$!
         wait $pid 2>/dev/null
         exitval=$?
         kill $progresspid 2>/dev/null


### PR DESCRIPTION
`kill $progresspid` was killing the subshell running `sleep 3` for each progress dot, but not killing the `sleep` itself.  Although the leaked `sleep` process had no functional effect, it irritated the Debian piuparts testing tool (“ERROR: FAIL: Processes are running inside chroot”).