### PR TITLE
Weak fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 RELEASE_DATE := "22-September-2014"
 RELEASE_MAJOR := 2
-RELEASE_MINOR := 2
-RELEASE_SUBLEVEL := 1
+RELEASE_MINOR := 3
+RELEASE_SUBLEVEL := 0
 RELEASE_EXTRALEVEL := .0
 RELEASE_NAME := dkms
 RELEASE_VERSION := $(RELEASE_MAJOR).$(RELEASE_MINOR).$(RELEASE_SUBLEVEL)$(RELEASE_EXTRALEVEL)
@@ -50,7 +50,7 @@ install:
 	install -p -m 0755 kernel_prerm.d_dkms  $(KCONF)/prerm.d/dkms
 	install -p -m 0755 kernel_postinst.d_dkms $(KCONF)/postinst.d/dkms
 
-DOCFILES=sample.spec sample.conf AUTHORS COPYING README.dkms sample-suse-9-mkkmp.spec sample-suse-10-mkkmp.spec
+DOCFILES=sample.spec sample.conf AUTHORS COPYING README.md sample-suse-9-mkkmp.spec sample-suse-10-mkkmp.spec
 
 doc-perms:
 	# ensure doc file permissions ok

--- a/dkms
+++ b/dkms
@@ -1896,8 +1896,8 @@ module_status_weak() {
     # $4 = kernel arch, $5 = kernel version built for
 	[ -z "$NO_WEAK_MODULES" ] || return 1
     [[ $weak_modules ]] || return 1
-    local m v k a weak_ko mod installed_ko f ret=1 oifs=$IFS
-    local -a already_found
+    local m v k a kern weak_ko mod installed_ko f ret=1 oifs=$IFS
+    local -A already_found
     for weak_ko in "$install_tree/"*/weak-updates/*; do
         [[ -e $weak_ko ]] || continue
         [[ -L $weak_ko ]] && installed_ko="$(readlink -f "$weak_ko")" || continue
@@ -1905,12 +1905,17 @@ module_status_weak() {
         kern=${weak_ko#$install_tree/}
         kern=${kern%/weak-updates/*}
         [[ $m = ${1:-*} && $v = ${2:-*} && $k = ${5:-*} && $a = ${4:-*} && $kern = ${3:-*} ]] || continue
+	already_found[$m/$v/$kern/$a/$k]+=${weak_ko##*/}" "
+    done
+    # Check to see that all ko's are present for each module
+    for mod in ${!already_found[@]}; do
+	IFS=/ read m v k a kern <<< "$mod"
+	# ensure each module is weak linked
+	for installed_ko in $(find $dkms_tree/$m/$v/$kern/$a/module -type f); do
+	    [[ ${already_found[$mod]} != *"$installed_ko"* ]] && continue 2
+	done
         ret=0
-        for f in "${already_found[@]}"; do
-            [[ $f = $m/$v/$kern/$a/$k ]] && continue 2
-        done
-        already_found[${#already_found[@]}]="$m/$v/$kern/$a/$k"
-        echo "installed-weak $m/$v/$kern/$a/$k"
+        echo "installed-weak $mod"
     done
     return $ret
 }

--- a/dkms.spec
+++ b/dkms.spec
@@ -163,7 +163,7 @@ fi
 
 %files
 %defattr(-,root,root)
-%doc sample.spec sample.conf AUTHORS COPYING README.dkms
+%doc sample.spec sample.conf AUTHORS COPYING README.md
 %if 0%{?fedora} >= 20 || 0%{?rhel} >= 7
 %{_unitdir}/%{name}.service
 %else


### PR DESCRIPTION
Some modules (zfs) have multiple ko's that they generate.  New modules need to be built and installed if any of them are missing from weak-updates (due to a conflict).  This prevents a module from being declared installed weak if any of the ko's are missing.

This also fixes the version in the Makefile and fixes "make rpm" for the README rename.