### PR TITLE
FIX dkms built issues for rhel kernel update ,change prerm script to …

### DIFF
--- a/dkms
+++ b/dkms
@@ -1723,7 +1723,9 @@ do_uninstall()
             fi
         fi
     done
-    rm -f "$dkms_tree/$module/kernel-$1-$2"
+    rm -rf "$dkms_tree/$module/kernel-$1-$2"
+    #Remove modules from dkms built tree
+    rm -rf "$dkms_tree/$module/$module_version/$1"
     else
         echo $""
         echo $"Status: This module version was INACTIVE for this kernel."

--- a/dkms.spec
+++ b/dkms.spec
@@ -134,7 +134,7 @@ rm -rf $RPM_BUILD_ROOT
 %if 0%{?fedora} >= 20 || 0%{?rhel} >= 7
 
 %post
-%systemd_post %{name}.service
+systemctl enable %{name}.service>/dev/null 2>&1
 
 %preun
 if [ $1 -eq 0 ]; then

--- a/kernel_prerm.d_dkms
+++ b/kernel_prerm.d_dkms
@@ -9,7 +9,7 @@ while read line; do
    vers=`echo "$line" | awk '{print $2}' | sed 's/,$//'`
    arch=`echo "$line" | awk '{print $4}' | sed 's/:$//'`
    echo "dkms: removing: $name $vers ($inst_kern) ($arch)" >&2
-   dkms remove -m $name -v $vers -k $inst_kern -a $arch
+   dkms uninstall -m $name -v $vers -k $inst_kern -a $arch
 done < <(dkms status -k $inst_kern 2>/dev/null | grep ": installed")
 fi
 


### PR DESCRIPTION
When user update kernel image to new version ,prerm script will remove all the dkms modules from old kernel tree. replace dkms remove with dkms uninstall ,after change ,dkms modules will be built and installed for new kernel image .
The Patch has been verifyed and test the updating issue .

[root@localhost 7.3.2]#  uname -a
Linux localhost.localdomain 3.10.0-514.el7.x86_64 #1 SMP Wed Oct 19 11:24:13 EDT 2016 x86_64 x86_64 x86_64 GNU/Linux

#rpm -Uvvh kernel-3.10.0-514.6.1.el7.x86_64.rpm

[root@localhost dkms]# dkms status
snd-hda-codec-realtek, 1.3: added
[root@localhost dkms]# dkms status
snd-hda-codec-realtek, 1.3, 3.10.0-514.6.1.el7.x86_64, x86_64: installed (original_module exists)
