### PR TITLE
Red hat cleanups

### DIFF
--- a/dkms
+++ b/dkms
@@ -1526,6 +1526,12 @@ install_module()
             exit 6
     }
 
+    # Make the newly installed modules available immediately
+    find /sys/devices -name modalias -print0 | xargs -0 cat | xargs modprobe -a -b -q
+    if [ -f /lib/systemd/system/systemd-modules-load.service ]; then
+        systemctl restart systemd-modules-load.service
+    fi
+
     # Do remake_initrd things (save old initrd)
     [[ $remake_initrd ]] && ! make_initrd "$kernelver" "$arch" && {
         do_uninstall "$kernelver" "$arch"

--- a/dkms
+++ b/dkms
@@ -426,10 +426,6 @@ override_dest_module_location()
     fi
 
     case "$running_distribution" in
-    fc[12345])
-        ;;
-    el[1234])
-        ;;
     sles[123456789])
         ;;
     suse[123456789])
@@ -2144,133 +2140,6 @@ driver_disk_suffix()
     esac
 }
 
-make_redhat_driver_disk()
-{
-    local i count
-    # Kludge to allow redhat1 driver disks with BOOT kernel modules (arch i386)
-    if [[ $distro = redhat1 && $multi_arch = true ]]; then
-        local redhat1_okay="true"
-        local other_arch=""
-        for ((i=0; i < ${#kernelver[@]}; i++)); do
-            if [[ ${arch[$i]} != i386 && $other_arch != ${arch[$i]} && $other_arch ]]; then
-                die 3 $"You have specified a Red Hat version 1 driver disk, but have also" \
-                    $"specified multiple architectures.  Version 1 does not support this." \
-                    $"Use 'redhat2' instead (only OSes >= RHEL3, FC1 support version 2)."
-            elif [[ ${arch[$i]} != i386 && $other_arch != ${arch[$i]} && ! $other_arch ]]; then
-                other_arch="${arch[$i]}"
-            fi
-        done
-    fi
-    if [ "$distro" == "redhat2" ]  && [ -z "$redhat1_okay" ]; then
-        echo $"Creating Red Hat v2 driver disk (arch support)."
-        echo $""
-        local rhdd_filename="rhdd"
-    elif [ "$distro" == "redhat3" ] && [ -z "$redhat1_okay" ]; then
-        echo $"Creating Red Hat v3 driver disk."
-        echo $""
-        make_redhat3_driver_disk
-        return
-    else
-        echo $"Creating Red Hat v1 driver disk."
-        echo $""
-        local rhdd_filename="rhdd-6.1"
-    fi
-
-    cpioarchive_dir_name=$(mktemp_or_die -d $tmp_location/dkms.XXXXXX)
-
-    for ((i=0; i < ${#kernelver[@]}; i++)); do
-        set_module_suffix "${kernelver[$i]}"
-
-        local dd_prefix="${kernelver[$i]}"
-        [[ $distro = redhat2 ]] && dd_prefix="${kernelver[$i]}/${arch[$i]}"
-        [[ $multi_arch = true && -z $redhat1_okay ]] && dd_prefix="${kernelver[$i]}/${arch[$i]}"
-        maybe_build_module "$module" "$module_version" "${kernelver[$i]}" "${arch[$i]}" || {
-            rm -rf "$cpioarchive_dir_name"
-            die 5 $"Cannot build $module/$module_version for redhat driver disk."
-        }
-
-        # FIXME: add check for KMP binary RPMs to include in the driver disk
-        if [[ ! $kernel_version_list ]]; then
-            kernel_version_list="kernel${kernelver[$i]}-${arch[$i]}"
-        else
-            kernel_version_list="$kernel_version_list-kernel${kernelver[$i]}-${arch[$i]}"
-        fi
-        mkdir -p $cpioarchive_dir_name/$dd_prefix
-        for f in "$dkms_tree/$module/$module_version/${kernelver[$i]}/${arch[$i]}/module/"*"$module_suffix"; do
-            [[ -f $f ]] || continue
-            echo "Marking ${f#$dkms_tree/$module/$module_version/}..."
-            cp "$f" "$cpioarchive_dir_name/$dd_prefix/"
-            modules_cgz_list="$dd_prefix/${f##*/} ${modules_cgz_list}"
-        done
-
-    done
-
-    # Create directory and necessary files
-    driver_disk_dir=$(mktemp_or_die -d $tmp_location/dkms.XXXXXX)
-
-    # Copy files for the driver disk (or warn if not present)
-    local files_for_driverdisk="modinfo disk-info modules.dep pcitable modules.pcimap pci.ids"
-    # Fedora Core 5 and higher, RHEL5 and higher, strictly require: rhdd, modules.cgz, modinfo, modules.alias, modules.dep
-    # which is in effect ignoring disk-info, pcitable, modules.pcimap and pci.ids
-    # and adding modules.alias, which will be generated.
-
-    local files_into_driverdisk="modules.cgz $rhdd_filename modules.alias"
-    for file in $files_for_driverdisk; do
-        if [[ -e $dkms_tree/$module/$module_version/source/redhat_driver_disk/$file ]]; then
-            files_into_driverdisk="$file $files_into_driverdisk"
-            cp -f "$dkms_tree/$module/$module_version/source/redhat_driver_disk/$file" "$driver_disk_dir/" 2>/dev/null
-        else
-            warn $"File: $file not found in $dkms_tree/$module/$module_version/source/redhat_driver_disk/"
-        fi
-    done
-    echo "$module-$module_version driver disk" > "$driver_disk_dir/$rhdd_filename"
-
-    # Make sure the kernel_version_list is not too long
-    if (( $(echo $kernel_version_list | wc -m | awk {'print $1'}) > 200 )); then
-        kernel_version_list="manykernels"
-    fi
-
-    local suffix="$(driver_disk_suffix)"
-    local image_dir="$dkms_tree/$module/$module_version/driver_disk"
-    local image_name="$module-$module_version-$kernel_version_list-dd.$suffix"
-    echo $""
-    echo $"Creating driver disk on $media media:"
-    cd "$cpioarchive_dir_name"
-    invoke_command "echo '$modules_cgz_list' | cpio -oH crc 2>/dev/null | gzip -9 > ./modules.cgz" "compressing modules.cgz" background
-    cp -f ./modules.cgz "$driver_disk_dir/"
-
-    # Generate modules.alias file
-    # On 2.4 kernels and kernels with no aliases. this won't yield anything.
-    touch ./modules.alias
-    for f in ${modules_cgz_list}; do
-        module_wo_suffix=$(basename ${f} ${module_suffix})
-        tmp_alias="./modules.alias.${module_wo_suffix}"
-        f="./${f}"
-        depmod -n ${f} 2>/dev/null | grep ^alias > ${tmp_alias}
-        if [[ -s ${tmp_alias} ]]; then
-            cat "${tmp_alias}" >> ./modules.alias
-        fi
-    done
-    [[ -e ./modules.alias ]] && cp -f ./modules.alias "$driver_disk_dir/"
-    # FIXME: add rpms/ directory, copy in KMP RPMs, run createrepo --pretty
-
-    cd - >/dev/null
-    rm -rf "$cpioarchive_dir_name"
-
-    mkdir -p "$image_dir"
-    rm -f "$image_dir/$image_name"
-
-    cd "$driver_disk_dir"
-    make_driver_disk_media "$image_dir/$image_name" "$driver_disk_dir"
-    cd - >/dev/null
-    rm -rf "$driver_disk_dir"
-
-    echo $""
-    echo $"Disk image location: $image_dir/$image_name"
-    echo $""
-    echo $"DKMS: mkdriverdisk completed."
-}
-
 make_driver_disk()
 {
     # Check that the right arguments were passed
@@ -2291,12 +2160,11 @@ make_driver_disk()
 
     # Confirm that distro is supported
     case $distro in
-        redhat | redhat[123] | suse | UnitedLinux | ubuntu)
+        redhat3 | suse | UnitedLinux | ubuntu)
             ;;
         *)
             die 3 $"Invalid distro argument. Currently, the distros" \
-                $"supported are: redhat, redhat1, redhat2, redhat3, suse, UnitedLinux" \
-                $"               ubuntu"
+                $"supported are: redhat3, suse, UnitedLinux, ubuntu"
             ;;
     esac
 
@@ -2305,7 +2173,7 @@ make_driver_disk()
 
     case $distro in
         redhat*)
-            make_redhat_driver_disk
+            make_redhat3_driver_disk
             ;;
         ubuntu)
             make_ubuntu_driver_disk
@@ -3417,7 +3285,7 @@ autoinstall() {
     done
 }
 
-function make_redhat3_driver_disk ()
+make_redhat3_driver_disk ()
 {
     # Check that the rpmbuild command is present
     if ! which rpmbuild >/dev/null 2>&1 ; then
@@ -3820,11 +3688,7 @@ fi
 
 # If initramfs/initrd rebuild is not requested, skip it with Redhat's weak-modules
 if [[ $no_initrd && $weak_modules ]]; then
-    if [[ $running_distribution == el5 ]]; then
-        weak_modules_no_initrd="--no-initrd"
-    else
-        weak_modules_no_initrd="--no-initramfs"
-    fi
+    weak_modules_no_initrd="--no-initramfs"
 fi
 
 # Default to -j<number of CPUs>

--- a/dkms.8
+++ b/dkms.8
@@ -795,14 +795,6 @@ This directive specifies whether your initrd should be remade after the module i
 onto the kernel.  Any text after the first character is ignored and if the first character
 is not a "y" or a "Y", it is assumed that REMAKE_INITRD="no".
 .TP
-.B UDEV_TRIGGER=
-This optional directive specifies, if the udev daemon will be get a trigger event after the module is installed 
-for your currently running kernel. Because this udev trigger might have some unfriendly side effects on some Linux 
-Systems, you can now disable this trigger, if your driver does not need it anyway.
-UDEV_TRIGGER=yes is assumed as the default, although this directive may not be given. This ensures backward compatibility
-to older DKMS releases. Any text after the first character is ignored and if the first character is not a "n" or a "N",
-it is assumed that UDEV_TRIGGER="yes". 
-.TP
 .B MODULES_CONF[#]=
 This directive array specifies what static configuration text
 lines need to be added into

--- a/dkms.8
+++ b/dkms.8
@@ -169,34 +169,12 @@ for single kernels or can be made to support multiple kernels.  To create
 a driver disk image with modules for multiple kernels, just specify multiple
 \-k parameters on the command line (\-k kernel1/arch1 \-k kernel2/arch2).
 
-Red Hat began supporting multi-arched driver disks in RHEL3.  To force creation
-of a driver disk with arch information, specify
-.B \-d redhat2
-or if you specify multiple architectures on the command-line and use
-.B \-d redhat
-, DKMS will create a version 2 driver disk.  By specifying
-.B \-d redhat1
-, you can force a version 1 driver disk image.
-
-Note that redhat1 driver disks actually supported multiple architectures when
-the second arch was i386 and the kernel module was for the BOOT kernel.  DKMS
-allows for this, and as such you can create a redhat1 style driver disk if the
-only other arch is i386 and the kernel name ends in BOOT.
-
 Red Hat introduced DDv3 starting with RHEL6. To create Red Hat DDv3, specify
 .B \-d redhat3
 and specify the specfile to use with
 .I \-\-spec=specfile.
 If no specfile is specified, DKMS will use
 .I /etc/dkms/template\-dkms\-redhat\-kmod.spec
-
-See
-.I http://people.redhat.com/dledford
-for more information on the Red Hat driver
-disk standards and which files are necessary to make a driver disk.
-
-Fedora Core 5 and higher, RHEL5 and higher require DKMS version 2.0.14
-or higher to generate a proper driver disk image.
 
 For suse/UnitedLinux driver disks, /usr/share/YaST2/modules/Vendor.ycp
 will also be copied to the driver disk; no other files are needed.
@@ -713,10 +691,8 @@ must be the same for each of BUILT_MODULE_NAME, BUILT_MODULE_LOCATION, DEST_MODU
 DEST_MODULE_LOCATION and that the numbering should start at 0 (eg. DEST_MODULE_LOCATION[0]="/kernel/drivers/something/"
 DEST_MODULE_LOCATION[1]="/kernel/drivers/other/").
 
-DEST_MODULE_LOCATION is ignored on Fedora Core 6 and higher, Red Hat
-Enterprise Linux 5 and higher, Novell SuSE Linux Enterprise Server 10
-and higher, Novell SuSE Linux 10.0 and higher, and Ubuntu. Instead,
-the proper distribution-specific directory is used.
+DEST_MODULE_LOCATION is ignored on Fedora and Red Hat Enterprise Linux, Novell SuSE Linux Enterprise Server 10
+and higher, Novell SuSE Linux 10.0 and higher, and Ubuntu. Instead, the proper distribution-specific directory is used.
 .TP
 .B MODULES_CONF_ALIAS_TYPE[#]=
 This directive array specifies how your modules should be aliased in

--- a/dkms.spec
+++ b/dkms.spec
@@ -1,16 +1,10 @@
-%if 0%{?rhel} == 5
-%define _sharedstatedir /var/lib
-%endif
-
 Summary: Dynamic Kernel Module Support Framework
 Name: dkms
 Version: [INSERT_VERSION_HERE]
 Release: 1%{?dist}
 License: GPLv2+
-Group: System Environment/Base
 BuildArch: noarch
 URL: https://github.com/dell/dkms
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Source0: http://linux.dell.com/dkms/permalink/dkms-%{version}.tar.gz
 # because Mandriva calls this package dkms-minimal
 Provides: dkms-minimal = %{version}

--- a/template-dkms-redhat-kmod.spec
+++ b/template-dkms-redhat-kmod.spec
@@ -3,18 +3,16 @@
 Name:		%{module_name}
 Version:	%{version}
 Release:	1%{?dist}
-Summary:	%{module_name}-%{version} RHEL6 Driver Update Program package
+Summary:	%{module_name}-%{version} RHEL Driver Update Program package
 
-Group:		System/Kernel
-License:	Unkown
+License:	Unknown
 Source0:	%{module_name}-%{version}.tar.bz2
-BuildRoot:	%(mktemp -ud %{_tmppath}/%{module_name}-%{version}-%{release}-XXXXXX)
 BuildRequires:	%kernel_module_package_buildreqs
 
 %kernel_module_package default
 
 %description
-%{module_name}-%{version} RHEL6 Driver Update package.
+%{module_name}-%{version} RHEL Driver Update package.
 
 %prep
 %setup
@@ -37,12 +35,3 @@ for flavor in %flavors_to_build ; do
 	make -C %{kernel_source $flavor} modules_install \
 		M=$PWD/obj/$flavor
 done
-
-%clean
-rm -rf $RPM_BUILD_ROOT
-
-%changelog
-* Sun Jun 15 2010 Prudhvi Tella <prudhvi_tella@dell.com>
-- DKMS template for RHEL6 Driver Update package.
-* Sun Mar 28 2010 Jon Masters <jcm@redhat.com>
-- Example RHEL6 Driver Update package.


### PR DESCRIPTION
I have commit access to the repository but would like to have some feedback on this.

This is a pull request for a few things:
- Remove UDEV_TRIGGER information from the man page as it has been deleted long ago
- Make sure on systemd systems that new modules are loaded after being built (rationale in the commit message)
- Remove stuff for old end of life Red Hat / Fedora versions.

I don't know how the policy for DKMS is; if you still want to support "dead" distributions for a while or not. Personally, I don't see the point for doing that. As the EPEL/Fedora maintainer of DKMS I'm not be able to push any new change to those EOL distributions.

Thanks,
--Simone