### PR TITLE
Revert "Make newly installed modules available immediately"

### DIFF
--- a/dkms
+++ b/dkms
@@ -1522,12 +1522,6 @@ install_module()
             exit 6
     }
 
-    # Make the newly installed modules available immediately
-    find /sys/devices -name modalias -print0 | xargs -0 cat | xargs modprobe -a -b -q
-    if [ -f /lib/systemd/system/systemd-modules-load.service ]; then
-        systemctl restart systemd-modules-load.service
-    fi
-
     # Do remake_initrd things (save old initrd)
     [[ $remake_initrd ]] && ! make_initrd "$kernelver" "$arch" && {
         do_uninstall "$kernelver" "$arch"


### PR DESCRIPTION
This reverts commit f5bfb12fef1fc06e56355cdba500eaa98d4e6aa8.

Modules installation should install modules, not load them. It creates issues when you build modules for non running kernels or when you do reload in a middle of a bunch of modules rebuild.
Moreover Arch Linux is not doing modules automatically.

See https://bugs.archlinux.org/task/54481