### PR TITLE
dkms build: Don't ignore -c if module is already built

### DIFF
--- a/dkms
+++ b/dkms
@@ -1565,7 +1565,10 @@ is_module_built() {
     [[ $1 && $2 && $3 && $4 ]] || return 1
     local d="$dkms_tree/$1/$2/$3/$4" m=''
     [[ -d $d/module ]] || return 1
-    read_conf_or_die "$3" "$4" "$dkms_tree/$1/$2/source/dkms.conf"
+    local default_conf="$dkms_tree/$1/$2/source/dkms.conf"
+    # If a custom dkms.conf was specified use it, otherwise use the default one.
+    local real_conf="${conf:-${default_conf}}"
+    read_conf_or_die "$3" "$4" "$real_conf"
     for m in "${dest_module_name[@]}"; do
         [[ -f $d/module/$m.ko || -f $d/module/$m.o ]] || return 1
     done


### PR DESCRIPTION
Currently, dkms build will always look for dkms.conf in
`$dkms_tree/<module>/<version>/source`, even if a custom one was specified
hrough -c. This is problematic for cases where dkms.conf is located in some
subdir of the module tree.

This patch changes is_module_built so that it'll first check whether $config
is set.