### PR TITLE
Run remove_initrd_backup after rebuilding the initrd

### DIFF
--- a/kernel_prerm.d_dkms
+++ b/kernel_prerm.d_dkms
@@ -11,8 +11,6 @@ remove_initrd_backup() {
 	done
 }
 
-remove_initrd_backup "$inst_kern"
-
 if [ -x /usr/sbin/dkms ]; then
 while read line; do
    name=`echo "$line" | awk '{print $1}' | sed 's/,$//'`
@@ -22,6 +20,8 @@ while read line; do
    dkms uninstall -m $name -v $vers -k $inst_kern -a $arch
 done < <(dkms status -k $inst_kern 2>/dev/null | grep ": installed")
 fi
+
+remove_initrd_backup "$inst_kern"
 
 rmdir --ignore-fail-on-non-empty \
 	"/lib/modules/$inst_kern/updates/dkms" \


### PR DESCRIPTION
The removal needs to happen before the dkms uninstall because the uninstall process creates a new initrd.  See here:

Removing linux-image-4.10.0-19-generic (4.10.0-19.21) ...
Examining /etc/kernel/prerm.d.
run-parts: executing /etc/kernel/prerm.d/dkms 4.10.0-19-generic /boot/vmlinuz-4.10.0-19-generic
removed '/boot/initrd.img-4.10.0-19-generic.old-dkms'
dkms: removing: r8168 8.043.02 (4.10.0-19-generic) (x86_64)

-------- Uninstall Beginning --------
Module: r8168
Version: 8.043.02
Kernel: 4.10.0-19-generic (x86_64)
-------------------------------------

Status: Before uninstall, this module version was ACTIVE on this kernel.

r8168.ko:
 - Uninstallation
   - Deleting from: /lib/modules/4.10.0-19-generic/updates/dkms/
 - Original module
   - No original module was found for this module on this kernel.
   - Use the dkms install command to reinstall any previous module version.

depmod...

Backing up initrd.img-4.10.0-19-generic to /boot/initrd.img-4.10.0-19-generic.old-dkms
Making new initrd.img-4.10.0-19-generic
(If next boot fails, revert to initrd.img-4.10.0-19-generic.old-dkms image)
update-initramfs...

DKMS: uninstall completed.
Examining /etc/kernel/postrm.d .