### PR TITLE
Fix to run under BusyBox shell

### DIFF
--- a/dkms
+++ b/dkms
@@ -1713,7 +1713,7 @@ do_uninstall()
         while [ "${dir_to_remove}" != "${dir_to_remove#/}" ]; do
             dir_to_remove="${dir_to_remove#/}"
         done
-        (cd "$install_tree/$1" && rmdir --parents --ignore-fail-on-non-empty "${dir_to_remove}" || true)
+        (cd "$install_tree/$1" && rm -rf "${dir_to_remove}/*" && rmdir -p "${dir_to_remove}" || true)
         echo $" - Original module"
         if [[ -e $dkms_tree/$module/original_module/$1/$2/${dest_module_name[$count]}$module_suffix ]]; then
             case "$running_distribution" in


### PR DESCRIPTION
Fix to run in Alpine Linux (BusyBox).

```
$ /bin/busybox rmdir --help
BusyBox v1.27.2 (2017-12-12 10:41:50 GMT) multi-call binary.

Usage: rmdir [OPTIONS] DIRECTORY...

Remove DIRECTORY if it is empty

	-p	Include parents
```