### PR TITLE
fix newest kernel calculation

### DIFF
--- a/dkms_common.postinst
+++ b/dkms_common.postinst
@@ -68,7 +68,7 @@ _get_newest_kernel_debian() {
         fi
 
         # if $kernel is greater than $COMPARE_TO
-        if [ `dpkg --compare-versions "$KERNEL_VERSION-$ABI" gt "$COMPARE_TO" && echo "yes" || \
+        if [ `dpkg --compare-versions "$KERNEL_VERSION-$ABI" ge "$COMPARE_TO" && echo "yes" || \
               echo "no"` = "yes" ]; then
             NEWEST_KERNEL=$KERNEL
             NEWEST_VERSION=$KERNEL_VERSION


### PR DESCRIPTION
In case when the latest kernel is alphabetically first, current code
fails to identify it and thus dkms will not be compiled for it in case
of upgrade scenario (when latest is not current yet).
Example is upgrade 4.9 to 4.14 (Debian Stretch -> Stretch-backports).

Reason is that KERNELS list is determined by ls, which sorts
alphabetically and 4.14 is alphabetically lower than 4.9.
Function _get_newest_kernel_debian then takes the first KERNELS entry
which is newest version as comparison base. Since no version can be
"greater than" the newest one in proper comparison performed by dpkg,
NEWEST_KERNEL veriable will be empty and dkms is recompiled only against
current kernel, not the newest one user is upgrading to.

There are multiple ways how to rewrite this function and I have chosen
change of comparison condition to "greater or equal to" which will
evaluate to true in case the version is equal, thus populate
NEWEST_KERNEL variable with the newest entry.