### PR TITLE
Fix version check when installing modules

### DIFF
--- a/dkms
+++ b/dkms
@@ -822,7 +822,8 @@ check_version_sanity()
         kernels_info[1]=${kernels_info[2]}
     fi
 
-    if [[ ${kernels_info[1]} && ${dkms_info[1]} && ${kernels_info[1]} = ${dkms_info[1]} && ! $force ]]; then
+    if [[ ${kernels_info[1]} && ${dkms_info[1]} && ${kernels_info[1]} = ${dkms_info[1]} &&
+	  -n "${kernels_info[0]}" && -n "${dkms_info[0]}" && ${kernels_info[0]} = ${dkms_info[0]} && ! $force ]]; then
         echo $"" >&2
         echo $"Good news! Module version $dkms_info for ${4}$module_suffix" >&2
         echo $"exactly matches what is already found in kernel $1." >&2


### PR DESCRIPTION
### Description 
DKMS wasn't checking the module version when installing newer kernel modules.  This fixes the issue (#14). 

### Motivation and Context

You can reproduce the issue by building ZFS's SPL (Solaris Porting Layer) kernel module under version 0.7.11 and then upgrading to 0.7.12.  SPL is a totally benign module and won't do anything without ZFS installed.  If you install SPL 0.7.11 and then upgrade to 0.7.12, dkms will not update the module.  Instead you'll see this message:
```
Good news! Module version 0.7.12-1 for spl.ko.xz
exactly matches what is already found in kernel 4.16.7-300.fc28.x86_64.
DKMS will not replace this module.
You may override by specifying --force.
...
--- Found version:        0.7.11-1
```
With this patch, you'll correctly see the module get updated:
```
spl.ko.xz:
Running module version sanity check.
 - Original module
   - This kernel never originally had a module by this name
 - Installation
   - Installing to /lib/modules/4.16.7-300.fc28.x86_64/extra/
...
--- Found version:        0.7.12-1
```

### Reproduce:
1. Download and build the SPL 0.7.11 and 0.7.12 RPMs:
```
#!/bin/bash

echo "--- building SPL 0.7.11 & 0.7.12 DKMS packages ---"
sudo yum groupinstall "Development Tools"
sudo yum install autoconf automake libtool wget libtirpc-devel rpm-build \
	zlib-devel libuuid-devel libattr-devel libblkid-devel libselinux-devel libudev-devel libaio-devel \
	install parted lsscsi ksh openssl-devel elfutils-libelf-devel \
	kernel-devel-$(uname -r)

wget https://github.com/zfsonlinux/zfs/releases/download/zfs-0.7.11/spl-0.7.11.tar.gz
tar -mxf spl-0.7.11.tar.gz
cd spl-0.7.11
./configure
make -s -j$(nproc)
make -j1 rpm-dkms
sed -i 's/0.7.11/0.7.12/g' META
./autogen.sh
./configure
make -s -j$(nproc)
make -j1 rpm-dkms
```

2. Install the 0.7.11 RPMs and then upgrade to 0.7.12:
```
echo "--- Removing existing SPL module (if any) ---"
sudo rpm -e spl-dkms 2>/dev/null || true

echo "--- Installing 0.7.11 module ---"
sudo yum -y localinstall spl-dkms-0.7.11-1.fc28.noarch.rpm

echo -n "--- Found "
modinfo /lib/modules/4.16.7-300.fc28.x86_64/extra/spl.ko.xz | grep ^version

echo "--- Installing 0.7.12 ---"
sudo yum -y localinstall spl-dkms-0.7.12-1.fc28.noarch.rpm

echo -n "--- Found "
modinfo /lib/modules/4.16.7-300.fc28.x86_64/extra/spl.ko.xz | grep ^version
```
