### PR TITLE
Do not touch original modules in /kernel

### DIFF
--- a/dkms
+++ b/dkms
@@ -1461,7 +1461,7 @@ install_module()
             $"You may override by specifying --force."
     fi
     local m=${dest_module_name[$count]}
-    local installed_modules=$(find_module "$lib_tree" "$m")
+    local installed_modules=$(find_module "$lib_tree" "$m" | grep -v "$lib_tree/kernel/")
     local module_count=${#installed_modules[@]}
     echo $" - Original module"
     local original_copy=$(compressed_or_uncompressed "$dkms_tree/$module/original_module/$kernelver/$arch" "$m")


### PR DESCRIPTION
DKMS confuses at least pacman by not moving original_module to its
original place in /kernel/...
As modules in /extra and /updates override modules in /kernel anyways it
is safe to leave orignal modules at their place in /kernel.

See #64 