### PR TITLE
Revert "FIX dkms built issues for rhel kernel update ,change prerm sc…

### DIFF
--- a/dkms
+++ b/dkms
@@ -1782,9 +1782,7 @@ do_uninstall()
             fi
         fi
     done
-    rm -rf "$dkms_tree/$module/kernel-$1-$2"
-    #Remove modules from dkms built tree
-    rm -rf "$dkms_tree/$module/$module_version/$1"
+    rm -f "$dkms_tree/$module/kernel-$1-$2"
     else
         echo $""
         echo $"Status: This module version was INACTIVE for this kernel."

--- a/kernel_prerm.d_dkms
+++ b/kernel_prerm.d_dkms
@@ -17,7 +17,7 @@ while read line; do
    vers=`echo "$line" | awk '{print $2}' | sed 's/,$//'`
    arch=`echo "$line" | awk '{print $4}' | sed 's/:$//'`
    echo "dkms: removing: $name $vers ($inst_kern) ($arch)" >&2
-   dkms uninstall -m $name -v $vers -k $inst_kern -a $arch
+   dkms remove -m $name -v $vers -k $inst_kern -a $arch
 done < <(dkms status -k $inst_kern 2>/dev/null | grep ": installed")
 fi
 


### PR DESCRIPTION
…ript to fix."

This reverts commit 0c19129b5d1f8e03498f6f2455ad9f7e14e9e606.

Creating this PR also for discussion, as we think the current behavior is wrong and not fitting the design defined in the manpage.

Per man dkms, the `uninstall` command should leave the uninstalled modules in the 'built' state and only removed after running `remove`. After this commit it seems that dkms uninstall started to remove the modules from the built tree, making them no longer stay in the 'built' state (they're not reported as such anymore).

This caused a regression in Ubuntu 19.04 where some of our other packages expected things to work as per the manpage. Quoting:
"Uninstalls an installed module/module-version combo from the kernel/arch passed in the -k option, or the current kernel if the -k option was not passed upon.  After uninstall completion, the driver will be left in the built state.
To completely remove a driver, the remove action should be utilized."

Without this change reverted, this does not seem to be the case anymore. After the revert, `dkms uninstall` seems to work as expected (and as it previously did). What was the rationale for the original change? What use-case was it fixing? The change description wasn't very descriptive.

Thank you!