### PR TITLE
fix: OBSOLETE_BY be blocked by --force (Closes #89)

### DIFF
--- a/dkms
+++ b/dkms
@@ -776,7 +776,7 @@ check_version_sanity()
         local -a my=(${1//-/ })
         local obsolete=0
         if [[ ${obs} && ${my} ]]; then
-            if [[ $(VER ${obs}) == $(VER ${my}) && ! $force ]]; then
+            if [[ $(VER ${obs}) == $(VER ${my}) ]]; then
                 # They get obsoleted possibly in this kernel release
                 if [[ ! ${obs[1]} ]]; then
                     # They were obsoleted in this upstream kernel
@@ -788,7 +788,7 @@ check_version_sanity()
                     # They were obsoleted in this ABI bump of the kernel
                     obsolete=1
                 fi
-            elif [[ $(VER ${my}) > $(VER ${obs}) && ! $force ]]; then
+            elif [[ $(VER ${my}) > $(VER ${obs}) ]]; then
                 # They were obsoleted in an earlier kernel release
                 obsolete=1
             fi


### PR DESCRIPTION
OBSOLETE_BY should higher priority than --force.
the idea is same as BUILD_EXCLUSIVE_KERNEL not be blocked by --force.