### PR TITLE
man: fix undefined macro 'OS'

### DIFF
--- a/dkms.8
+++ b/dkms.8
@@ -226,8 +226,8 @@ on just one system and then use
 on all of your other systems to get the same built modules loaded
 without having to wait for anything to compile.
 .SY ldtarball
-.OS /path/to/tarball.tar
-.OS --force
+.OP /path/to/tarball.tar
+.OP --force
 .YS
 .IP "" 4
 This takes a tarball made from the


### PR DESCRIPTION
Found from salsa-ci pipeline [job 257545](https://salsa.debian.org/vicamo-guest/dkms/-/jobs/257545)

Signed-off-by: You-Sheng Yang <vicamo@gmail.com>