### PR TITLE
mkdeb postinst template - automatic architecture detection bug fixed

### DIFF
--- a/template-dkms-mkdeb/debian/postinst
+++ b/template-dkms-mkdeb/debian/postinst
@@ -10,7 +10,7 @@ NAME=MODULE_NAME
 PACKAGE_NAME=$NAME-dkms
 DEB_NAME=$(echo $PACKAGE_NAME | sed 's,_,-,')
 CVERSION=`dpkg-query -W -f='${Version}' $DEB_NAME | awk -F "-" '{print $1}' | cut -d\: -f2`
-ARCH=`dpkg --print-architecture`
+ARCH=`dpkg-architecture -qDEB_BUILD_GNU_CPU`
 
 dkms_configure () {
 	for POSTINST in /usr/lib/dkms/common.postinst "/usr/share/$PACKAGE_NAME/postinst"; do


### PR DESCRIPTION
By default, in Debian systems for DKMS kernel modules, amd64 architecture named as "x86_64".
But name of debian packaging architecture is amd64. `dpkg --print-architecture` should return amd64.
This fix change this command to `dpkg-architecture -qDEB_BUILD_GNU_CPU`.

#### How to reproduce:
1. execute this commands
`git clone https://github.com/p5-vbnekit/dkmshello.git`
`(cd dkmshello && dkms mkdeb --source-only)`
`apt install ./p5-dkmshello-dkms_*_*.deb`
2. watch `dkms status`: p5-dkmshello, 1.0, 5.2.0-2-amd64, **amd64**: installed

#### However, the most popular packages generate this:
- aufs, 5.2+20190902, 5.2.0-2-amd64, **x86_64**: installed
- bbswitch, 0.8, 5.2.0-2-amd64, **x86_64**: installed
- nvidia-current, 430.40, 5.2.0-2-amd64, **x86_64**: installed
