### PR TITLE
Force version override by file in /usr/share/dkms/modules_to_force_install/

### DIFF
--- a/dkms
+++ b/dkms
@@ -784,7 +784,7 @@ check_version_sanity()
         local -a my=(${1//-/ })
         local obsolete=0
         if [[ ${obs} && ${my} ]]; then
-            if [[ $(VER ${obs}) == $(VER ${my}) ]]; then
+            if [[ $(VER ${obs}) == $(VER ${my}) && ! $force ]]; then
                 # They get obsoleted possibly in this kernel release
                 if [[ ! ${obs[1]} ]]; then
                     # They were obsoleted in this upstream kernel
@@ -796,7 +796,7 @@ check_version_sanity()
                     # They were obsoleted in this ABI bump of the kernel
                     obsolete=1
                 fi
-            elif [[ $(VER ${my}) > $(VER ${obs}) ]]; then
+            elif [[ $(VER ${my}) > $(VER ${obs}) && ! $force ]]; then
                 # They were obsoleted in an earlier kernel release
                 obsolete=1
             fi

--- a/dkms
+++ b/dkms
@@ -136,7 +136,7 @@ show_usage()
     echo $"  [action]  = { add | remove | build | install | uninstall | match | autoinstall | mkdriverdisk |"
     echo $"                mktarball | ldtarball | mkrpm | mkkmp | mkdeb | mkdsc | mkbmdeb | status }"
     echo $"  [options] = [-m module] [-v module-version] [-k kernel-version] [-a arch]"
-    echo $"              [-d distro] [-c dkms.conf-location] [-q] [--force] [--all]"
+    echo $"              [-d distro] [-c dkms.conf-location] [-q] [--force] [--force-version-override] [--all]"
     echo $"              [--templatekernel=kernel] [--directive='cli-directive=cli-value']"
     echo $"              [--config=kernel-.config-location] [--archive=tarball-location]"
     echo $"              [--kernelsourcedir=source-location] [--no-prepare-kernel] [--no-initrd]"
@@ -815,6 +815,11 @@ check_version_sanity()
     read -a kernels_module < <(find_module "$lib_tree" "${4}")
     [ -z $kernels_module ] && return 0
 
+    if [[ "$force_version_override" == "true" ]]; then
+        # Skip the following version checking code.
+        return 0
+    fi
+
     if [[ ${kernels_module[1]} ]]; then
         warn $"Warning! Cannot do version sanity checking because multiple ${4}$module_suffix" \
             $"modules were found in kernel $1."
@@ -1431,6 +1436,10 @@ force_installation()
 
         for elem in $to_force; do
             if [ "${1}" = "${elem}" ]; then
+                echo "force"
+                return 0
+            elif [ "${1}_version-override" = "${elem}" ]; then
+                echo "version-override"
                 return 0
             fi
         done
@@ -1452,9 +1461,14 @@ install_module()
     tmp_force="$force"
 
     # If the module is set to be force-installed
-    force_installation $module && echo "Forcing installation of $module" \
-        && force="true"
-
+    local ret=$(force_installation $module)
+    if [[ "$ret" == "force" ]];then
+        force="true"
+        echo "Forcing installation of $module"
+    elif [[ "$ret" == "version-override" ]];then
+        force_version_override="true"
+        echo "Forcing version override of $module"
+    fi
     # Make sure that kernel exists to install into
     [[ -e $install_tree/$kernelver ]] || die 6 \
         $"The directory $install_tree/$kernelver doesn't exist." \
@@ -3580,6 +3594,7 @@ kernel_source_dir=""
 ksourcedir_fromcli=""
 action=""
 force=""
+force_version_override=""
 no_prepare_kernel=""
 no_clean_kernel=""
 binaries_only=""
@@ -3662,6 +3677,9 @@ while (($# > 0)); do
             ;;
         --force)
             force="true"
+            ;;
+        --force-version-override)
+            force_version_override="true"
             ;;
         --all)
             all="true"


### PR DESCRIPTION
for https://github.com/dell/dkms/issues/42, I reverted 
546195f and add a new parameter, because there may some people counting on '--force' as highest priority for installation.

so let's list scenarios be covered here:
1. user needs to force install the dkms without any checking. 
 - this is a way which already exists, not be changed by this patch.
 - by '--force' or write dkms name in files under /usr/share/dkms/modules_to_force_install/
 - in this case, obsolete_by will not work, because of '--force' is the highest priority which behaves same as the logic before comment 546195f.

2. user need to force install the dkms, but also would like to retire that dkms once kernel fixes the issue.
 - this way is added by this patch.
 - by '--force-version-override' or write {dkms name}_version-override in  files under /usr/share/dkms/modules_to_force_install/
 - then obsolete_by in dkms.conf will get higher priority.
 - log for a test installation with version override only
   - to simulate the case that fix not in kernel so user need a dkms
   - http://paste.ubuntu.com/p/9bw9r7wrbZ/
 - log for a test installation with version override and obsoleted_by
   - to simulate the case that fix already in kernel so user wants an online update retiring dkms.
   - http://paste.ubuntu.com/p/nrGtygyF3X/

