### PR TITLE
Add support for UEFI Secure Boot validation toggling through shim

### DIFF
--- a/dkms
+++ b/dkms
@@ -1416,6 +1416,7 @@ clean_build()
 
 sign_build()
 {
+    [[ -x "$(command -v kmodsign)" && -d "/var/lib/shim-signed/mok/" ]] || return
     local base_dir="$dkms_tree/$module/$module_version/$kernelver/$arch"
     if type update-secureboot-policy >/dev/null 2>&1; then
         echo $"Signing module:"

--- a/dkms
+++ b/dkms
@@ -1414,10 +1414,29 @@ clean_build()
     rm -rf "$dkms_tree/$module/$module_version/build"
 }
 
+sign_build()
+{
+    local base_dir="$dkms_tree/$module/$module_version/$kernelver/$arch"
+    if type update-secureboot-policy >/dev/null 2>&1; then
+        echo $"Signing module:"
+        SHIM_NOTRIGGER=y update-secureboot-policy --new-key
+        for ko in `find "$base_dir/module/" -name "*.ko" -print`;
+        do
+            echo " - $ko"
+            kmodsign sha512 \
+                /var/lib/shim-signed/mok/MOK.priv \
+                /var/lib/shim-signed/mok/MOK.der \
+                "$ko"
+        done
+        update-secureboot-policy --enroll-key
+    fi
+}
+
 build_module()
 {
     prepare_build
     do_build
+    sign_build
     clean_build
     echo $""
     echo $"DKMS: build completed."

--- a/dkms_common.postinst
+++ b/dkms_common.postinst
@@ -6,6 +6,8 @@
 
 set -e
 
+. /usr/share/debconf/confmodule
+
 uname_s=$(uname -s)
 
 _get_kernel_dir() {


### PR DESCRIPTION
This allows one to install third-party drivers and still have their system
work (albeit without full Secure Boot validation), automatizing the step
of disabling validation in shim.

Users still have the possibility to notice this and skip the step, thus
not disabling Secure Boot (but then, they will not be able to load the
dkms drivers that were added).