### PR TITLE
Do not /dev/null dkms_autoinstaller

### DIFF
--- a/kernel_postinst.d_dkms
+++ b/kernel_postinst.d_dkms
@@ -36,7 +36,7 @@ case "${uname_s}" in
 esac
 
 if [ -x /usr/lib/dkms/dkms_autoinstaller ]; then
-    exec /usr/lib/dkms/dkms_autoinstaller start $inst_kern > /dev/null
+    exec /usr/lib/dkms/dkms_autoinstaller start $inst_kern
 fi
 
 if ! _check_kernel_dir $inst_kern ; then


### PR DESCRIPTION
Do not invoke dkms_autoinstaller from /etc/kernel/header_postinst.d/dkms
with redirection to /dev/null (LP: #1827697), this caused debconf dialog
to not be shown.