### PR TITLE
dkms: mkbmdeb should have versioned "Provides:"

### DIFF
--- a/template-dkms-mkdeb/debian/control
+++ b/template-dkms-mkdeb/debian/control
@@ -7,5 +7,6 @@ Standards-Version: 3.8.1
 
 Package: DEBIAN_PACKAGE-dkms
 Architecture: DEBIAN_BUILD_ARCH
+Provides: DEBIAN_PACKAGE-modules (= MODULE_VERSION)
 Depends: dkms (>= 1.95), ${misc:Depends}
 Description: DEBIAN_PACKAGE driver in DKMS format.


### PR DESCRIPTION
to help packages satisfy the dependency

See Debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=943484 for rationale and discussion