### PR TITLE
continuation of fix for mkdeb mode

### DIFF
--- a/dkms
+++ b/dkms
@@ -3033,7 +3033,11 @@ make_debian()
     make_common_test "mk${create_type}"
 
     debian_package=${module//_/-}
-    debian_build_arch=$(dpkg-architecture -qDEB_BUILD_ARCH)
+    if [[ $source_only ]]; then
+         debian_build_arch='all'
+    else
+         debian_build_arch=$(dpkg-architecture -qDEB_BUILD_ARCH)
+    fi
 
     # Read the conf file
     read_conf_or_die "$kernelver" "$arch"
@@ -3091,7 +3095,7 @@ make_debian()
             die 7 $"There was a problem creating your ${create_type}."
         echo $""
         echo $"DKMS: mk${create_type} completed."
-        invoke_command "mv '$temp_dir/${debian_package}-dkms_${module_version}_all.deb' '$deb_basedir'" "Moving built files to $deb_basedir"
+        invoke_command "mv '$temp_dir/${debian_package}-dkms_${module_version}_${debian_build_arch}.deb' '$deb_basedir'" "Moving built files to $deb_basedir"
 	;;
     bmdeb)
         local archive_location="$dkms_tree/$module/$module_version/tarball/$module-$module_version.dkms.tar.gz"


### PR DESCRIPTION
Triggered by this [this commit](https://github.com/dell/dkms/commit/1af7589044c6b788fca922e069a53cb00e673e4c) (where fixed mkdeb skeleton template). After this patch debian package generator will produce `${package_name_and_version}_${debian_build_arch}.deb` (in case of default skeleton), but:
1. in `source-only` mode mkdeb should generate `${package_name_and_version}_all.deb`

2. anyway, whithout this patch dkms will try to find `${package_name_and_version}_all.deb`
because current original code from master is:
```
deb)
  invoke_command "cp -Lpr '$dkms_tree/$module/$module_version/source' '$temp_dir_debian/$module-$module_version'" "Copying source tree"
  invoke_command "dpkg-buildpackage -rfakeroot -d -b -us -uc 1>/dev/null" "Building binary package" || \
    die 7 $"There was a problem creating your ${create_type}."
  echo $""
  echo $"DKMS: mk${create_type} completed."
  invoke_command "mv '$temp_dir/${debian_package}-dkms_${module_version}_all.deb' '$deb_basedir'" "Moving built files to $deb_basedir"
  ;;
```

My commit motivated by [this patch](https://bugs.debian.org/cgi-bin/bugreport.cgi?att=2;bug=832558;filename=source_deb.patch;msg=5) from [same bug report](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=832558). Maybe be author of [this commit](https://github.com/dell/dkms/commit/1af7589044c6b788fca922e069a53cb00e673e4c) just forgot about it?