### PR TITLE
Source the debconf module only if available on the system

### DIFF
--- a/dkms_common.postinst
+++ b/dkms_common.postinst
@@ -6,7 +6,7 @@
 
 set -e
 
-. /usr/share/debconf/confmodule
+[ -f /usr/share/debconf/confmodule ] && . /usr/share/debconf/confmodule
 
 uname_s=$(uname -s)
 


### PR DESCRIPTION
(Fixes comment on https://github.com/dell/dkms/commit/b25cb7e4668e45104e77ed65d43360743668d51e )