### PR TITLE
Stop sanity check from resetting module_compressed_suffix.

### DIFF
--- a/dkms
+++ b/dkms
@@ -812,7 +812,7 @@ check_version_sanity()
             return 1
         fi
     fi
-    set_module_suffix
+    set_module_suffix "$1"
     read -a kernels_module < <(find_module "$lib_tree" "${4}")
     [ -z $kernels_module ] && return 0
 


### PR DESCRIPTION
When installing a kernel that uses `KERNEL_XZ` from a kernel that uses `KERNEL_GZ`, DKMS *almost* works. It builds the modules, keeps them in `/var/lib/dkms`, and mistakenly believes that it has successfully copied them into the target kernel's tree (which makes attempts to diagnose with `dkms status` or to rebuild with `dkms install` confusing, to say the least). Long night on this one.

The problem is that right before the installation, `check_version_sanity` runs. It fails to pass the intended kernel version to `set_module_suffix`, causing it to analyze the tree for `uname -r` and forget the compression suffix for the kernel we're trying to use. Let's fix that.

This PR works for now, but may want to consider removing the default parameter from `set_module_suffix` entirely to make sure this type of thing can't slip under the rug again.