### PR TITLE
Revert "Do not touch original modules in /kernel"

### DIFF
--- a/dkms
+++ b/dkms
@@ -1524,7 +1524,7 @@ install_module()
             $"You may override by specifying --force."
     fi
     local m=${dest_module_name[$count]}
-    local installed_modules=$(find_module "$lib_tree" "$m" | grep -v "$lib_tree/kernel/")
+    local installed_modules=$(find_module "$lib_tree" "$m")
     local module_count=${#installed_modules[@]}
     echo $" - Original module"
     local original_copy=$(compressed_or_uncompressed "$dkms_tree/$module/original_module/$kernelver/$arch" "$m")


### PR DESCRIPTION
This breaks detecting original modules and causing it to skip `modprob`ing the module because it already exists in `/kernel`. In such case, we have to install new modules under `/updates`. `/extra` is for **new** modules that don't exist in `/kernel`.

Revert this commit until we fix the issue.

This reverts commit ec531cec047abeabf6cd5531b9834eeeb817d6a1.