### PR TITLE
Add script for newer Fedora to run existing postinst/prerm scripts

### DIFF
--- a/kernel_install.d_dkms
+++ b/kernel_install.d_dkms
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+if [[ "$1" == "add" ]]; then
+	/etc/kernel/postinst.d/dkms $2
+fi
+
+if [[ "$1" == "remove" ]]; then
+	/etc/kernel/prerm.d/dkms $2
+fi


### PR DESCRIPTION
Pursuant to Fedora bug https://bugzilla.redhat.com/show_bug.cgi?id=1753044, and openzfs issue https://github.com/zfsonlinux/zfs/issues/9868.

The issue is that there is surprising behavior to users expecting that ZFS (and other DKMS-built modules in Fedora) are not auto-built for new kernels by the out-of-the-box configuration of DKMS.  This has nothing to do with ZFS per se; it is a change in how Fedora invokes kernel installation hooks.  DKMS in its present state depends on an older behavior.

Fedora has moved away from effectively requiring the grubby package to run the postinst/prerm scripts in newer Fedoras (30+).  However, the grubby package is still available and usable.

My proposal is to add a new script in the new /etc/kernel/install.d directory, which selectively calls either the existing postinst or prerm script, which would stay in their current locations.  F30+ DKMS packages in Fedora can add the new install.d script.  My hope is that the other OS's that DKMS supports can simply ignore the new script and not have to make changes.

This is what I suspect to be the least disruptive way of handling the problem.  If this PR is accepted I intend to work with the Feodra packaging of DKMS to bring it to present and future supported Fedora releases.  If I am wrong in any of my assumptions, I'm happy to refine my submission.