### PR TITLE
build_module: do not build if result will be obsolete

### DIFF
--- a/dkms
+++ b/dkms
@@ -1439,6 +1439,13 @@ sign_build()
 
 build_module()
 {
+    local buildable=0
+    for ((count=0; count < ${#built_module_name[@]}; count++)); do
+        check_version_sanity "$kernelver" "$arch" "$obsolete_by" "${dest_module_name[$count]}" || continue
+        ((buildable++))
+    done
+    ((buildable!=0)) || exit 0
+
     prepare_build
     do_build
     sign_build


### PR DESCRIPTION
The OBSOLETE_BY mechanism provides a nice way of skipping modules that
aren't meant for particular kernels, such as the case where drivers have
gone upstream, like WireGuard. It has the desirable property that it
prints a reasonable and informative message to the user. This is in
contrast to BUILD_EXCLUSIVE_KERNEL, which will return an "Error!" to the
user if the condition isn't met. However, one drawback of OBSOLETE_BY is
that it is only invoked after the build phase. But most of the time, if
a particular kernel obsoletes a module, the old out-of-tree dkms module
probably won't build any more. So it makes sense to move the nice text
and check into the build phase as well, which is what this commit does.

We ran into this issue on Debian, where we attempted to fix the current
issue with [1] but are now running into bug reports like [2]. We
initially wanted to use OBSOLETE_BY but couldn't due to the issue that
this commmit fixes.

[1] https://salsa.debian.org/debian/wireguard-linux-compat/-/blob/debian/master/debian/patches/0002-Avoid-trying-to-compile-on-debian-5.5-kernels-Closes.patch
[2] https://bugs.debian.org/956893

CC @dkg @unit193