### PR TITLE
dkms: don't use UID to check for root user, but use instead id -u tha…

### DIFF
--- a/dkms
+++ b/dkms
@@ -3016,7 +3016,7 @@ debian_install()
     done
     # if they are already installed, we are OK.
     [[ ${package[@]} ]] || return
-    if ((UID != 0)); then
+    if [[ $(id -u) != 0 ]]; then
         # figure out how to get root
         for getroot in su-to-root gksudo kdesu sudo; do
             which $getroot >/dev/null 2>&1 || continue
@@ -3258,7 +3258,7 @@ parse_moduleversion(){
 }
 
 check_root() {
-    ((UID == 0)) && return
+    [[ $(id -u) = 0 ]] && return
     die 1 $"You must be root to use this command."
 }
 
@@ -3913,7 +3913,7 @@ for action_to_run in $action; do
         show_status
         ;;
     ldtarball) # Make sure they're root if we're using --force
-        if ((UID != 0)) && [[ $force = true ]]; then
+        if [[ $(id -u) != 0 ]] && [[ $force = true ]]; then
             die 1 $"You must be root to use this command with the --force option."
         fi
         load_tarball && add_module


### PR DESCRIPTION
…t returns the effective user.

This patch is inspired from the hint of Thorsten Glaser <t.glaser@tarent.de>
in Debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956245