### PR TITLE
Do not require root access for the build command

### DIFF
--- a/dkms
+++ b/dkms
@@ -3886,7 +3886,8 @@ for action_to_run in $action; do
         check_root && make_driver_disk
         ;;
     build)
-        check_root && check_all_is_banned "build" && build_modules
+        [ ! -w "$dkms_tree" ] && die 1 $"No write access to create a DKMS tree at ${dkms_tree}"
+        check_all_is_banned "build" && build_modules
         ;;
     add)
         check_root && check_all_is_banned "add" && add_module


### PR DESCRIPTION
Commit bd13868dcb1d9d6b89cc60edcd5a7a022bce516e broke the build command when running without root access. Building as a non-root user is useful in some cases and is described in the man page as a supported feature.

See the discussion in #134

Fixes #134