### PR TITLE
Compatibility with ALT Linux

### DIFF
--- a/dkms
+++ b/dkms
@@ -1823,7 +1823,7 @@ do_uninstall()
         while [ "${dir_to_remove}" != "${dir_to_remove#/}" ]; do
             dir_to_remove="${dir_to_remove#/}"
         done
-        (cd "$install_tree/$1" && rmdir -p --ignore-fail-on-non-empty "${dir_to_remove}" || true)
+        (if cd "$install_tree/$1"; then rpm -qf "${dir_to_remove}" >/dev/null 2>&1 || rmdir -p --ignore-fail-on-non-empty "${dir_to_remove}"; fi || true)
         echo $" - Original module"
         local origmod=$(compressed_or_uncompressed "$dkms_tree/$module/original_module/$1/$2" "${dest_module_name[$count]}")
         if [[ -n "$origmod" ]]; then

--- a/dkms
+++ b/dkms
@@ -1003,7 +1003,7 @@ moduleconfig_remove()
 
 etc_sysconfig_kernel_modify()
 (
-    [[ -e /etc/sysconfig/kernel && $remake_initrd ]] || return 0
+    [[ -f /etc/sysconfig/kernel && $remake_initrd ]] || return 0
 
     # Make a temp directory to store files
     local temp_dir_name=$(mktemp_or_die -d $tmp_location/dkms.XXXXXX)

--- a/test/dkms_test-1.0/dkms.conf
+++ b/test/dkms_test-1.0/dkms.conf
@@ -3,9 +3,10 @@ PACKAGE_NAME="dkms_test"
 PACKAGE_VERSION="1.0"
 BUILT_MODULE_NAME="dkms_test"
 
-MAKE="make -C /lib/modules/${kernelver}/build SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
+# MAKE="make -C /lib/modules/${kernelver}/build SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
+# CLEAN="make -C /lib/modules/${kernelver}/build SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build  M=$PWD clean"
 
-CLEAN="make -C /lib/modules/${kernelver}/build SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build  M=$PWD clean"
+AUTOINSTALL="yes"
 
 REMAKE_INITRD="yes"
 


### PR DESCRIPTION
Mainly:
* `/etc/sysconfig/kernel` is directory.
* Do not `rmdir` module installation directory if it's belonging to rpm package. (After second thought I think this patch is not so important, but it does not hurt either.)
* We use `dkms_test-1.0` for dkms CI testing, make its `dkms.conf` suitable for it, removing `MAKE` & `CLEAN`options with obsolete build syntax. Add `AUTOINSTALL` which is (I think is) useful for example and testing.
