### PR TITLE
dkms_common.postinst: fix _get_newest_kernel_rhel

### DIFF
--- a/dkms_common.postinst
+++ b/dkms_common.postinst
@@ -82,33 +82,9 @@ _get_newest_kernel_debian() {
     echo "$NEWEST_KERNEL"
 }
 
-# Get the most recent kernel in Rhel based systems. If the current kernel
-# is the most recent kernel then the function will print a null string.
+# Get the most recent kernel in Rhel based systems.
 _get_newest_kernel_rhel() {
-    NEWEST_KERNEL=
-
-    LAST_INSTALLED_KERNEL=$(rpm -q --whatprovides kernel  --last | grep kernel -m1 | cut -f1 -d' ')
-
-    LIK_FORMATTED_NAME=$(rpm -q $LAST_INSTALLED_KERNEL --queryformat="%{VERSION}-%{RELEASE}.%{ARCH}\n")
-
-    if [ `echo $LIK_FORMATTED_NAME | grep 2.6 >/dev/null` ]; then
-        # Fedora and Suse
-        NEWEST_KERNEL=$LIK_FORMATTED_NAME
-    else
-        # Hack for Mandriva where $LIK_FORMATTED_NAME is broken
-        LIK_NAME=$(rpm -q $LAST_INSTALLED_KERNEL --queryformat="%{NAME}\n")
-        LIK_TYPE=${LIK_NAME#kernel-}
-        LIK_TYPE=${LIK_TYPE%%-*}
-        LIK_STRIPPED=${LIK_NAME#kernel-}
-        LIK_STRIPPED=${LIK_STRIPPED#$LIK_TYPE-}
-        LIK_STRIPPED_BASE=${LIK_STRIPPED%%-*}
-        LIK_STRIPPED_END=${LIK_STRIPPED#$LIK_STRIPPED_BASE-}
-        LIK_FINAL=$LIK_STRIPPED_BASE-$LIK_TYPE-$LIK_STRIPPED_END
-
-        NEWEST_KERNEL=$LIK_FINAL
-    fi
-
-    echo $NEWEST_KERNEL
+    rpm -q --qf="%{VERSION}-%{RELEASE}.%{ARCH}\n" --whatprovides kernel | tail -n 1
 }
 
 # Get the newest kernel on Debian and Rhel based systems.


### PR DESCRIPTION
This patch updates the _get_newest_kernel_rhel function to work with
modern RHEL and derivatives. Previously, it worked only with distros
running a 2.6.x kernel or Mandriva Linux (dissolved 2015).

Signed-off-by: Gregory Bartholomew <gregory.lee.bartholomew@gmail.com>