### PR TITLE
dkms_common.postinst: simplify _is_kernel_name_correct

### DIFF
--- a/dkms_common.postinst
+++ b/dkms_common.postinst
@@ -31,19 +31,11 @@ _check_kernel_dir() {
 
 # Check the existence of a kernel named as $1
 _is_kernel_name_correct() {
-    CORRECT="no"
-    KERNEL_NAME=$1
-
-    for kernel in /boot/config-*; do
-        [ -f "$kernel" ] || continue
-        KERNEL=${kernel#*-}
-        if [ "${KERNEL}" = "${KERNEL_NAME}" ]; then
-            CORRECT="yes"
-            break
-        fi
-    done
-
-    echo $CORRECT
+    if [ -e "/lib/modules/$1" ]; then
+        echo yes
+    else
+        echo no
+    fi
 }
 
 


### PR DESCRIPTION
This patch removes the _is_kernel_name_correct function's dependency on
on the existence of the /boot/config-* files. Instead, of keying on the
existence of the /boot/config-* files, this patch changes the function
to key on the existence of the /lib/modules/* directories. This change
is necessary for modern distributions such as Fedora 33 that have
switched to the newer Boot Loader Specification (BLS). Systemd-boot, in
particular, does not create the /boot/config-* files when new kernels
are added with its kernel-install script.

Signed-off-by: Gregory Bartholomew <gregory.lee.bartholomew@gmail.com>