### PR TITLE
Update kernel_install.d_dkms to remove wrong bash path

### DIFF
--- a/kernel_install.d_dkms
+++ b/kernel_install.d_dkms
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 if [[ "$1" == "add" ]]; then
 	/etc/kernel/postinst.d/dkms $2


### PR DESCRIPTION
See:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=986674

Lintian emits

E: dkms: wrong-path-for-interpreter etc/dkms/kernel_install.d_dkms (#!/usr/bin/bash != /bin/bash)