### PR TITLE
kernel_prerm.d: fix for new dkms status format

### DIFF
--- a/kernel_prerm.d_dkms
+++ b/kernel_prerm.d_dkms
@@ -13,9 +13,9 @@ remove_initrd_backup() {
 
 if [ -x /usr/sbin/dkms ]; then
 while read line; do
-   name=`echo "$line" | awk '{print $1}' | sed 's/,$//'`
-   vers=`echo "$line" | awk '{print $2}' | sed 's/,$//'`
-   arch=`echo "$line" | awk '{print $4}' | sed 's/:$//'`
+   name=`echo "$line" | awk '{print $1}' | sed 's/,$//'` | cut -d'/' -f1
+   vers=`echo "$line" | awk '{print $1}' | sed 's/,$//'` | cut -d'/' -f2
+   arch=`echo "$line" | awk '{print $3}' | sed 's/:$//'`
    echo "dkms: removing: $name $vers ($inst_kern) ($arch)" >&2
    dkms remove -m $name -v $vers -k $inst_kern -a $arch
 done < <(dkms status -k $inst_kern 2>/dev/null | grep ": installed")


### PR DESCRIPTION
Commit f83b758b6fb8ca67b1ab65df9e3d2a1e994eb483 ("Print 'module/version'
and not 'module, version' when doing dkms status.") changed the output
format of dkms status command.

This broke the prerm.d script.

Fix to use the new format