### PR TITLE
Add dest override for Archlinux

### DIFF
--- a/dkms
+++ b/dkms
@@ -497,6 +497,9 @@ override_dest_module_location()
     Debian*)
         echo "/updates/dkms" && return
         ;;
+    Arch*)
+        echo "/updates/dkms" && return
+        ;;
     *)
         ;;
     esac


### PR DESCRIPTION
Currently a vast majority of Linux distros prefer to keep DKMS modules
separate from the ones shipped with the kernel.

This provides a clear separation and distinction between the two. In
similar fashion, the pre-build out-of-tree kernel modules shipped in
Arch are placed under extramodules/.

Simply reuse the existing updates/dkms, since updates is already in the
kmod search path.