### PR TITLE
dkms: move modprobe-on-install behind a toggle

### DIFF
--- a/dkms
+++ b/dkms
@@ -143,7 +143,7 @@ show_usage()
     echo $"              [--kernelsourcedir=source-location] [--no-prepare-kernel] [--no-initrd]"
     echo $"              [--binaries-only] [--source-only] [-r release (SuSE)] [--verbose]"
     echo $"              [--size] [--spec=specfile] [--media=floppy|iso|tar] [--legacy-postinst=0|1]"
-    echo $"              [--no-depmod] [-j number] [--version]"
+    echo $"              [--no-depmod] [--modprobe-on-install] [-j number] [--version]"
 }
 
 VER()
@@ -1625,10 +1625,12 @@ install_module()
             exit 6
     }
 
-    # Make the newly installed modules available immediately
-    find /sys/devices -name modalias -print0 | xargs -0 cat | xargs modprobe -a -b -q
-    if [ -f /lib/systemd/system/systemd-modules-load.service ]; then
-        systemctl restart systemd-modules-load.service
+    if [[ $modprobe_on_install ]]; then
+        # Make the newly installed modules available immediately
+        find /sys/devices -name modalias -print0 | xargs -0 cat | xargs modprobe -a -b -q
+        if [ -f /lib/systemd/system/systemd-modules-load.service ]; then
+            systemctl restart systemd-modules-load.service
+        fi
     fi
 
     # Do remake_initrd things (save old initrd)
@@ -3608,6 +3610,7 @@ die_is_fatal="yes"
 [ -x /sbin/weak-modules ] && weak_modules='/sbin/weak-modules'
 [ -x /usr/lib/module-init-tools/weak-modules ] && weak_modules='/usr/lib/module-init-tools/weak-modules'
 no_depmod=""
+modprobe_on_install=""
 
 action_re='^(remove|(auto|un)?install|match|mk(driverdisk|tarball|rpm|deb|bmdeb|dsc|kmp)|(un)?build|add|status|ldtarball)$'
 
@@ -3723,6 +3726,9 @@ while (($# > 0)); do
             ;;
         --no-depmod)
             no_depmod="true"
+            ;;
+        --modprobe-on-install)
+            modprobe_on_install="true"
             ;;
         --debug)
             export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '

--- a/dkms.8
+++ b/dkms.8
@@ -503,6 +503,9 @@ and
 .B uninstall
 which will avoid (re)calculating module dependencies and thereby save time.
 .TP
+.B \-\-modprobe\-on\-install
+This option modprobes the modules upons successful installation
+.TP
 .B \-\-kernelsourcedir <kernel\-source\-directory\-location>
 Using this option you can specify the location of your kernel source
 directory.  Most likely you will not need to set this if your kernel


### PR DESCRIPTION
With commit f5bfb12 ("Make newly installed modules available
immediately") dkms started loading the kernel modules, upon install.

While this resolves the original RedHat issue, it has undesired effect
for other distributions.

If distributions want this, they can flip the toggle and carry on.
There's no point in enforcing one distribution's decision onto everyone.

Fixes: f5bfb12 ("Make newly installed modules available immediately")

Supersedes https://github.com/dell/dkms/pull/27

@seblu - Arch
@jwrdegoede - RedHat/Fedora
@adrelanos  @rhertzog - Debian