### PR TITLE
Fix kernel removing

### DIFF
--- a/kernel_prerm.d_dkms
+++ b/kernel_prerm.d_dkms
@@ -13,8 +13,8 @@ remove_initrd_backup() {
 
 if [ -x /usr/sbin/dkms ]; then
 while read line; do
-   name=`echo "$line" | awk '{print $1}' | sed 's/,$//'` | cut -d'/' -f1
-   vers=`echo "$line" | awk '{print $1}' | sed 's/,$//'` | cut -d'/' -f2
+   name=`echo "$line" | awk '{print $1}' | sed 's/,$//' | cut -d'/' -f1`
+   vers=`echo "$line" | awk '{print $1}' | sed 's/,$//' | cut -d'/' -f2`
    arch=`echo "$line" | awk '{print $3}' | sed 's/:$//'`
    echo "dkms: removing: $name $vers ($inst_kern) ($arch)" >&2
    dkms remove -m $name -v $vers -k $inst_kern -a $arch


### PR DESCRIPTION
...
run-parts: executing /etc/kernel/prerm.d/dkms 5.14.8-1 /boot/vmlinuz-5.14.8-1
dkms: removing:   (5.14.8-1) (x86_64)
Error! Arguments <module> and <module-version> are not specified.
Usage: remove <module>/<module-version> or
       remove -m <module>/<module-version> or
       remove -m <module> -v <module-version>
...