### PR TITLE
Support CC=clang and LD=ld.lld

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -575,6 +575,23 @@ read_conf()
     [[ ! $make_command ]] && make_command="make -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
     [[ ! $clean ]] && clean="make -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build clean"
 
+    # Check if clang was used to compile or lld was used to link the kernel.
+    if [[ -e $kernel_source_dir/vmlinux ]]; then
+      if  readelf -p .comment $kernel_source_dir/vmlinux | grep -q clang; then
+        make_command="${make_command} CC=clang"
+      fi
+      if  readelf -p .comment $kernel_source_dir/vmlinux | grep -q LLD; then
+        make_command="${make_command} LD=ld.lld"
+      fi
+    elif [[ -e $kernel_source_dir/.config ]]; then
+      if grep -q CONFIG_CC_IS_CLANG=y $kernel_source_dir/.config; then
+        make_command="${make_command} CC=clang"
+      fi
+      if grep -q CONFIG_LD_IS_LLD=y $kernel_source_dir/.config; then
+        make_command="${make_command} LD=ld.lld"
+      fi
+    fi
+
     # Set patch_array (including kernel specific patches)
     count=0
     for ((index=0; index < ${#PATCH[@]}; index++)); do


### PR DESCRIPTION
When building the Linux kernel, one may use `make LLVM=1` to set
multiple flags, akin to `make CC=clang LD=ld.lld NM=llvm-nm ...` (see
the link below for kernel docs explaining this further in detail).

When building kernel modules, to ensure we're using the same toolchain
as the underlying core kernel image, Kbuild will error if it's reinvoked
with a toolchain that differs. This causes DKMS to fail, since it's not
re-specifying the same compiler (or linker, etc).

Check the .comment section of the vmlinux file in the Linux kernel
source dir, and set CC= and LD= flags for make based on that.

If vmlinux does not exist, grep .config for CONFIG_CC_IS_CLANG=y and
CONFIG_LD_IS_LLD=y.

Fixes: #124
Fixes: https://github.com/ClangBuiltLinux/linux/issues/1104
Link: https://docs.kernel.org/kbuild/llvm.html
Suggested-by: Colin Ian King <colin.king@canonical.com>
Signed-off-by: Nick Desaulniers <nick.desaulniers@gmail.com>