### PR TITLE
Fix creation of temp build dir

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -872,7 +872,7 @@ prepare_build()
 
     # Set up temporary build directory for build
     rm -rf "$build_dir"
-    cp -a "$source_dir" "$build_dir"
+    cp -a "$source_dir/" "$build_dir"
 
     cd "$build_dir"
 


### PR DESCRIPTION
Since `$source_dir` is just a symlink to the actual source directory, using `cp -a` on it just copies the symlink instead of the contents.

This makes the build fail when the source directory isn't writable.

Commit d038a604bf525b01d7bd12b98706b1f861e4ea27 broke this when it dropped the trailing slash.