### PR TITLE
Enable using add, build and install with a directory again

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -2347,7 +2347,6 @@ remove | unbuild | uninstall)
     ${action}_module
     ;;
 add | build | install)
-    check_module_args $action
     check_all_is_banned $action # TODO: fix/enable --all
     [[ $action = install ]] && check_root || check_rw_dkms_tree
     ${action}_module


### PR DESCRIPTION
Since commit e73f9bbf2013 ("dkms: fixup add/remove...uninstall permission checking"), it was no longer possible to use "dkms add" with a directory:

    $ dkms add test/dkms_test-1.0
    Error! Arguments <module> and <module-version> are not specified.
    Usage: add <module>/<module-version> or
           add -m <module>/<module-version> or
           add -m <module> -v <module-version>

But when options `-m` and `-v` are given, the source directory is ignored.

Fix this issue by removing the check for `-m` and `-v` in `add`, `build` and `install` actions. This makes the following commands work again (for example on Arch Linux):

    $ dkms add test/dkms_test-1.0
    Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0

    $ dkms remove -m dkms_test -v 1.0 --all
    ...
    $ dkms install -k 5.15.2-arch1-1 test/dkms_test-1.0
    Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0

    Building module:
    cleaning build area...
    make -j8 KERNELRELEASE=5.15.2-arch1-1 -C /lib/modules/5.15.2-arch1-1/build M=/var/lib/dkms/dkms_test/1.0/build...
    cleaning build area...

    dkms_test.ko:
    Running module version sanity check.
     - Original module
       - No original module exists within this kernel
     - Installation
       - Installing to /lib/modules/5.15.2-arch1-1/kernel/extra/
    depmod...

    $ dkms remove -m dkms_test -v 1.0 --all
    ...
    $ dkms build -k 5.15.2-arch1-1 test/dkms_test-1.0
    Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0

    Building module:
    cleaning build area...
    make -j8 KERNELRELEASE=5.15.2-arch1-1 -C /lib/modules/5.15.2-arch1-1/build M=/var/lib/dkms/dkms_test/1.0/build...
    cleaning build area...

Fixes: https://github.com/dell/dkms/issues/177