### PR TITLE
Fix Linux distribution identification through /etc/os-release

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -317,7 +317,7 @@ distro_version()
 {
     if [[ -r /etc/os-release ]]; then
         . /etc/os-release
-        [[ ${#ID_LIKE[@]} ]] && echo ${ID_LIKE[0]} || echo $ID
+        [[ ${#ID_LIKE[@]} != 0 ]] && echo ${ID_LIKE[0]} || echo $ID
         return
     fi
 


### PR DESCRIPTION
On Linux distributions such as Arch Linux, `/etc/os-release` contains:

    NAME="Arch Linux"
    PRETTY_NAME="Arch Linux"
    ID=arch
    BUILD_ID=rolling
    ANSI_COLOR="38;2;23;147;209"
    HOME_URL="https://archlinux.org/"
    DOCUMENTATION_URL="https://wiki.archlinux.org/"
    SUPPORT_URL="https://bbs.archlinux.org/"
    BUG_REPORT_URL="https://bugs.archlinux.org/"
    LOGO=archlinux-logo

There is no `ID_LIKE` property, so `${#ID_LIKE[@]}` is zero:

    $ . /etc/os-release
    $ echo ${#ID_LIKE[@]}
    0

As `0` is not empty, `[[ ${#ID_LIKE[@]} ]]` is true:

    $ [[ ${#ID_LIKE[@]} ]] ; echo $?
    0

So in `dkms`, the function `distro_version` returns an empty string in

    [[ ${#ID_LIKE[@]} ]] && echo ${ID_LIKE[0]} || echo $ID

Fix this by replacing `[[ ${#ID_LIKE[@]} ]]` with `[[ ${#ID_LIKE[@]} != 0]]`.

Fixes: f0b11ce07005 ("dkms: rework distribution detection")