### PR TITLE
test: generalize matching lines with several dots

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -36,7 +36,7 @@ run_with_expected_output() {
     cat > test_cmd_expected_output.log
     if "$@" > test_cmd_output.log 2>&1 ; then
         # "depmod..." lines can have multiple points. Replace them, to be able to compare
-        sed 's/\(depmod\|build\)\.\.\.\.*$/\1.../' -i test_cmd_output.log
+        sed 's/\([^.]\)\.\.\.\.*$/\1.../' -i test_cmd_output.log
         # On CentOS, weak-modules is executed. Drop it from the output, to be more generic
         sed '/^Adding any weak-modules$/d' -i test_cmd_output.log
         sed '/^Removing any linked weak-modules$/d' -i test_cmd_output.log


### PR DESCRIPTION
dkms sometimes invokes commands in background and wait for them by display a dot once every 3 seconds (this logic is implemented in function `invoke_command`). This makes it difficult to compare the output of the command with a reference one.

In the tests, replace every sequence of 4 dots or more with 3 dots, when they appear at the end of line. This should fix issues such as the one which occurred in https://github.com/dell/dkms/runs/4249192349