### PR TITLE
Fix source only tarballs unpacked with ldtarball

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1809,6 +1809,8 @@ load_tarball()
             die 8  $"$PACKAGE_NAME-$PACKAGE_VERSION is already added!" \
             $"Aborting."
         fi
+        # Success!
+        break
     done
 
     module="$PACKAGE_NAME"; module_version="$PACKAGE_VERSION"


### PR DESCRIPTION
When the tarball is created with

dkms mktarball -m dkms_test -v 1.0 --archive test.tar --source-only

The tarball has the form
dkms_main_tree/
dkms_source_tree/dkms.conf
dkms_source_tree/dkms_test.c
dkms_source_tree/Makefile

In the loop over the locations

    for loc in dkms_source_tree dkms_binaries_only ''; do

The first loc is successful.
The second fails with
Error! No valid dkms.conf in dkms_source_tree or dkms_binaries_only.

A break is needed to catch the first success.

Suggested-by: Jan Edler <jan.edler@indexengines.com>
Signed-off-by: Tom Rix <trix@redhat.com>