### PR TITLE
{ld,mk}tarball: perform expansion when setting cleanup trap

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1665,8 +1665,8 @@ make_tarball()
     # Read the conf file
     read_conf_or_die "$kernelver" "$arch"
 
-    temp_dir_name=$(mktemp_or_die -d $tmp_location/dkms.XXXXXX)
-    trap 'rm -rf $temp_dir_name' EXIT
+    local -r temp_dir_name=$(mktemp_or_die -d $tmp_location/dkms.XXXXXX)
+    trap "rm -rf $temp_dir_name" EXIT
     mkdir -p $temp_dir_name/dkms_main_tree
 
     if [[ $source_only ]]; then
@@ -1776,7 +1776,7 @@ load_tarball()
 
     # Untar it into $tmp_location
     local -r temp_dir_name=$(mktemp_or_die -d $tmp_location/dkms.XXXXXX)
-    trap 'rm -rf $temp_dir_name' EXIT
+    trap "rm -rf $temp_dir_name" EXIT
     tar -xaf $archive_location -C $temp_dir_name
 
     if [[ ! $temp_dir_name/dkms_main_tree ]]; then


### PR DESCRIPTION
ldtarball stored the name of the temporary directory where the
archive was to be extracted to in a local variable, and set a
trap to clean up the directory upon exit. The trap was set with
single quotes, meaning that the value of $temp_dir_name was
expanded when the trap was run, at which point the variable was
out of scope.

Change the trap to use double quotes, which expands the variable
when the trap is set, allowing the cleanup of the ldtarball
staging directory to work correctly. mktarball also used single
quotes, but its cleanup trap worked correctly because mktarball's
temp_dir_name variable was not locally scoped. For consistency,
change mktarball's temp_dir_name to a local variable and set the
trap with double quotes.

For dell/dkms#190: ldtarball doesn't clean up after itself

Signed-off-by: Daniel Dadap <ddadap@nvidia.com>