### PR TITLE
Port kernel_*.d_dkms to /bin/sh, shellcheck-clean

### DIFF
--- a/kernel_install.d_dkms
+++ b/kernel_install.d_dkms
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
-if [[ "$1" == "add" ]]; then
-	/etc/kernel/postinst.d/dkms $2
+if [ "$1" = "add" ]; then
+	/etc/kernel/postinst.d/dkms "$2"
 fi
 
-if [[ "$1" == "remove" ]]; then
-	/etc/kernel/prerm.d/dkms $2
+if [ "$1" = "remove" ]; then
+	/etc/kernel/prerm.d/dkms "$2"
 fi

--- a/kernel_postinst.d_dkms
+++ b/kernel_postinst.d_dkms
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # We're passed the version of the kernel being installed
 inst_kern=$1
@@ -11,17 +11,16 @@ _get_kernel_dir() {
        Linux)          DIR="/lib/modules/$KVER/build" ;;
        GNU/kFreeBSD)   DIR="/usr/src/kfreebsd-headers-$KVER/sys" ;;
     esac
-    echo $DIR
+    echo "$DIR"
 }
 
 _check_kernel_dir() {
-    DIR=$(_get_kernel_dir $1)
+    DIR=$(_get_kernel_dir "$1")
     case ${uname_s} in
-       Linux)          test -e $DIR/include ;;
-       GNU/kFreeBSD)   test -e $DIR/kern && test -e $DIR/conf/kmod.mk ;;
-       *)              return 1 ;;
+       Linux)          test -e "$DIR/include" ;;
+       GNU/kFreeBSD)   test -e "$DIR/kern" && test -e "$DIR/conf/kmod.mk" ;;
+       *)              false ;;
     esac
-    return $?
 }
 
 case "${uname_s}" in
@@ -36,10 +35,10 @@ case "${uname_s}" in
 esac
 
 if [ -x /usr/lib/dkms/dkms_autoinstaller ]; then
-    exec /usr/lib/dkms/dkms_autoinstaller start $inst_kern
+    exec /usr/lib/dkms/dkms_autoinstaller start "$inst_kern"
 fi
 
-if ! _check_kernel_dir $inst_kern ; then
+if ! _check_kernel_dir "$inst_kern" ; then
     echo "dkms: WARNING: $kernel headers are missing, which may explain the above failures." >&2
     echo "      please install the $header_pkg package to fix this." >&2
 fi

--- a/kernel_prerm.d_dkms
+++ b/kernel_prerm.d_dkms
@@ -1,16 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 # We're passed the version of the kernel being removed
 inst_kern=$1
 
-if [ -x /usr/sbin/dkms ]; then
-while read line; do
-   name=`echo "$line" | awk '{print $1}' | sed 's/,$//' | cut -d'/' -f1`
-   vers=`echo "$line" | awk '{print $1}' | sed 's/,$//' | cut -d'/' -f2`
-   arch=`echo "$line" | awk '{print $3}' | sed 's/:$//'`
-   echo "dkms: removing: $name $vers ($inst_kern) ($arch)" >&2
-   dkms remove -m $name -v $vers -k $inst_kern -a $arch
-done < <(dkms status -k $inst_kern 2>/dev/null | grep ": installed")
+if command -v dkms > /dev/null; then
+	dkms status -k "$inst_kern" 2>/dev/null | while IFS=",:/ " read -r name vers _ arch status; do
+		[ "$status" = "installed" ] || continue
+		echo "dkms: removing: $name $vers ($inst_kern) ($arch)" >&2
+		dkms remove -m "$name" -v "$vers" -k "$inst_kern" -a "$arch"
+	done
 fi
 
 rmdir --ignore-fail-on-non-empty \


### PR DESCRIPTION
Also gets a nasty line parsing hunk out of prerm (I count at *least* 9 extra processes, assuming bash optimises builtins perfectly)