### PR TITLE
Respect PATH

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -2125,7 +2125,7 @@ autoinstall() {
 #############################
 
 # Set a standard path
-PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/lib/dkms"
+PATH="$PATH:/usr/lib/dkms"
 
 # Ensure files and directories we create are readable to anyone,
 # since we aim to build as a non-root user


### PR DESCRIPTION
Many distros may place CC and LD outside the hardcoded path here. For
instance on Gentoo, LLVM goes into /usr/lib/llvm/$SLOT/ (where slot
could be 13 for instance), and the slots are added into PATH from /etc/env.d/.

This works, and I'm not sure of any issue with respecting PATH rather
than hardcoding something generic.