### PR TITLE
sign_build: prefer scripts/sign-file to kmodsign

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -995,23 +995,59 @@ clean_build()
     rm -rf "$dkms_tree/$module/$module_version/build"
 }
 
+# Different distros put scripts/sign-file in different places
+locate_sign_file()
+{
+    local kernel_release="$(uname -r)"
+    local debian_location="/usr/lib/linux-kbuild-${kernel_release%.*}/scripts/sign-file"
+    local ubuntu_location="/usr/src/linux-headers-$kernel_release/scripts/sign-file"
+    local fedora_location="/usr/src/kernels/$kenel_release/scripts/sign-file"
+
+    if [ -x "$debian_location" ]; then
+        echo "$debian_location"
+    elif [ -x "$ubuntu_location" ]; then
+        echo "$ubuntu_location"
+    elif [ -x "$fedora_location" ]; then
+        echo "$fedora_location"
+    elif command -v kmodsign >/dev/null; then
+        echo "kmodsign"
+    else
+        echo "not_found"
+    fi
+}
+
 sign_build()
 {
-    [[ -x "$(command -v kmodsign)" && -d "/var/lib/shim-signed/mok/" ]] || return
-    local base_dir="$dkms_tree/$module/$module_version/$kernelver/$arch"
-    if type update-secureboot-policy >/dev/null 2>&1; then
-        echo $"Signing module:"
-        SHIM_NOTRIGGER=y update-secureboot-policy --new-key
-        for ko in `find "$base_dir/module/" -name "*.ko" -print`;
-        do
-            echo " - $ko"
-            kmodsign sha512 \
-                /var/lib/shim-signed/mok/MOK.priv \
-                /var/lib/shim-signed/mok/MOK.der \
-                "$ko"
-        done
-        update-secureboot-policy --enroll-key
+    local sign_file="$(locate_sign_file)"
+    if [ "$sign_file" = "not_found" ]; then
+        echo "scripts/sign-file not found, module won't be signed"
+        return
     fi
+    if [ ! -d "/var/lib/shim-signed/mok/" ]; then
+        echo "/var/lib/shim-signed/mok/ does not exist, module won't be signed"
+        return
+    fi
+    if ! command -v update-secureboot-policy >/dev/null; then
+        echo "update-secureboot-policy not found, module won't be signed"
+        return
+    fi
+
+    # update-secureboot-policy is not part of upstream shim, so this is
+    # effectively only useful for Debian and Ubuntu derivatives.
+    # https://git.launchpad.net/~ubuntu-core-dev/shim/+git/shim-signed/tree/update-secureboot-policy
+
+    local base_dir="$dkms_tree/$module/$module_version/$kernelver/$arch"
+    echo $"Signing module:"
+    SHIM_NOTRIGGER=y update-secureboot-policy --new-key
+    for ko in `find "$base_dir/module/" -name "*.ko" -print`;
+    do
+        echo " - $ko"
+        "$sign_file" sha512 \
+            /var/lib/shim-signed/mok/MOK.priv \
+            /var/lib/shim-signed/mok/MOK.der \
+            "$ko"
+    done
+    update-secureboot-policy --enroll-key
 }
 
 do_build()


### PR DESCRIPTION
The (really useful) `sign_build()` function was introduced a while ago in b25cb7e4668e45104e77ed65d43360743668d51e, and it relies on `kmodsign` to sign kernel modules so that they can be used in a Secure Boot environment.

Unfortunately, `kmodsign` only exists in Ubuntu, so this function was quite useless on other distros.

In this commit I made it possible to instead use [`scripts/sign-file`](https://www.kernel.org/doc/html/latest/admin-guide/module-signing.html#manually-signing-modules). They do exactly the same thing, as `kmodsign` is based on the same code and adds just a couple of extra options, but sign-file is included in the upstream kernel and is more broadly available.

To avoid potentially breaking existing setups, `kmodsign` is kept as a fallback.

`sign_build()` still makes use of `update-secureboot-policy`, a tool that exists only on Debian and Ubuntu, so this patch currently improves the situation only for Debian.

I've also made the function a bit more verbose, addressing Gianfranco's concerns when submitting his patch: https://github.com/dell/dkms/pull/104#discussion_r339418815

I'd really like to hear @LocutusOfBorg's feedback, if possible, as he originally submitted the `sign_build()` patch a few years ago :)