### PR TITLE
Fix Typo in Install Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ commands:
 
 ```
 make install
-make install_debian
+make install-debian
 make install-redhat
 ```
 


### PR DESCRIPTION
Replaces the underscore in `install_debian` with a dash -> `install-debian`