### PR TITLE
dkms.service: use %v specifier and drop sh usage

### DIFF
--- a/dkms.service
+++ b/dkms.service
@@ -5,7 +5,7 @@ Documentation=man:dkms(8)
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/bin/sh -c 'dkms autoinstall --verbose --kernelver $(uname -r)'
+ExecStart=dkms autoinstall --verbose --kernelver %v
 
 [Install]
 Before=network-pre.target graphical.target


### PR DESCRIPTION
As mentioned in the `systemd.unit(5)` manpage, the `%v` specifier is "Identical to `uname -r` output". The full list of specifiers is available here: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers