### PR TITLE
Fix typo in dkms_framework.conf

### DIFF
--- a/dkms_framework.conf
+++ b/dkms_framework.conf
@@ -25,7 +25,7 @@
 # non-null value:
 # autoinstall_all_kernels=""
 
-# Location of the sign-file kernel binary (default: depends on distributioin):
+# Location of the sign-file kernel binary (default: depends on distribution):
 # sign_file="/path/to/sign-file"
 
 # Location of the key and certificate used for Secure boot (default: /var/lib/dkms):


### PR DESCRIPTION
Changes `distributioin` to `distribution` in dkms_framework.conf