### PR TITLE
dkms.in: skip sign_file call when unset

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1030,7 +1030,9 @@ actual_build()
                     kmodsign sha512 $mok_signing_key $mok_certificate "$built_module"
                     ;;
                 *)
-                    eval $sign_file sha512 $mok_signing_key $mok_certificate "$built_module"
+                    if [ -n "${sign_file}" ]; then
+                        eval $sign_file sha512 $mok_signing_key $mok_certificate "$built_module"
+                    fi
                     ;;
             esac
         fi


### PR DESCRIPTION
The module-signing script is located in prepare_signing(). It is
possible for installation to proceed, even if no signing file is located
on the system. In that case, the script promises that signing will not
occur.

However, in actual_build(), there is no check for the case where
$sign_file is unset. So `eval "" sha512 ...` is executed instead - which
is a nonsense command.

If $sign_file is unset, skip signing.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

# Testing
Installing a module on a distro which doesn't distribute the signing script, would report.
```
Building for 5.10.115-rt67
Building initial module for 5.10.115-rt67
/usr/sbin/dkms: line 1033: sha512: command not found
Done.
```
With this change compiled into `dkms`, the `sha512: command...` error is no longer present.