### PR TITLE
dkms: Change deprecated egrep for grep -E

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -448,7 +448,7 @@ should be put into
 .B MAKE[0].
 Other entries in the MAKE array will only be used if their corresponding entry in
 .B MAKE_MATCH[#]
-matches, as a regular expression (using egrep), the kernel that the module is being built for.
+matches, as a regular expression (using grep -E), the kernel that the module is being built for.
 Note that if no value is placed in
 .B MAKE_MATCH[#]
 for any

--- a/dkms.in
+++ b/dkms.in
@@ -1549,7 +1549,7 @@ remove_module()
     done
 
     # Delete the $module_version part of the tree if no other $module_version/$kernel_version dirs exist
-    if ! find $dkms_tree/$module/$module_version/* -maxdepth 0 -type d 2>/dev/null | egrep -qv "(build|tarball|driver_disk|rpm|deb|source)$"; then
+    if ! find $dkms_tree/$module/$module_version/* -maxdepth 0 -type d 2>/dev/null | grep -Eqv "(build|tarball|driver_disk|rpm|deb|source)$"; then
         echo $"Deleting module $module-$module_version completely from the DKMS tree."
         rm -rf "$dkms_tree/$module/$module_version"
     fi


### PR DESCRIPTION
New versions of grep is going to issue a warning when `egrep` is used.

    egrep: warning: egrep is obsolescent; using grep -E

This changes the invocation to `grep -E`

Signed-off-by: Morten Linderud <morten@linderud.pw>