### PR TITLE
Makefile: make gzip man page reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ install: dkms dkms.8
 	install -D -m 0755 kernel_install.d_dkms $(KCONF)/install.d/dkms
 	install -D -m 0755 kernel_postinst.d_dkms $(KCONF)/postinst.d/dkms
 	install -D -m 0755 kernel_prerm.d_dkms $(KCONF)/prerm.d/dkms
-	gzip -9 $(MAN)/dkms.8
+	gzip -n -9 $(MAN)/dkms.8
 
 install-redhat: install
 	install -D -m 0755 dkms_find-provides $(LIBDIR)/find-provides


### PR DESCRIPTION
By default gzip records the timestamp so when reproducing dkms this is a problem.

Signed-off-by: Jelle van der Waa <jelle@archlinux.org>

The non-reproducible output can be observed here https://reproducible.archlinux.org/api/v0/builds/338097/diffoscope