### PR TITLE
refactor: Use `$()` instead of legacy backticks

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1963,8 +1963,8 @@ run_match()
 
     # Iterate over the kernel_status and match kernel to the template_kernel
     while read template_line; do
-        template_module=`echo "$template_line" | awk {'print $1'} | sed 's/,$//'`
-        template_version=`echo "$template_line" | awk {'print $2'} | sed 's/,$//'`
+        template_module=$(echo "$template_line" | awk {'print $1'} | sed 's/,$//')
+        template_version=$(echo "$template_line" | awk {'print $2'} | sed 's/,$//')
 
         # Print out a match header
         echo $"Module:  $template_module"

--- a/dkms_autoinstaller
+++ b/dkms_autoinstaller
@@ -44,7 +44,7 @@ case "$1" in
 		if [ -n "$2" ]; then
 			kernel="$2"
 		else
-			kernel=`uname -r`
+			kernel=$(uname -r)
 		fi
 		if [ -f /etc/dkms/no-autoinstall ]; then
 			log_daemon_msg "$prog: autoinstall for dkms modules has been disabled"

--- a/dkms_common.postinst
+++ b/dkms_common.postinst
@@ -63,8 +63,8 @@ _get_newest_kernel_debian() {
         fi
 
         # if $kernel is greater than $COMPARE_TO
-        if [ `dpkg --compare-versions "$KERNEL_VERSION-$ABI" ge "$COMPARE_TO" && echo "yes" || \
-              echo "no"` = "yes" ]; then
+        if [ $(dpkg --compare-versions "$KERNEL_VERSION-$ABI" ge "$COMPARE_TO" && echo "yes" || \
+              echo "no") = "yes" ]; then
             NEWEST_KERNEL=$KERNEL
             NEWEST_VERSION=$KERNEL_VERSION
             NEWEST_ABI=$ABI
@@ -91,14 +91,14 @@ get_newest_kernel() {
         CURRENT_ABI=${CURRENT_ABI%%-*}
         NEWEST_KERNEL=$(_get_newest_kernel_debian "$CURRENT_VERSION-$CURRENT_ABI")
 
-    elif [ `which rpm >/dev/null` ]; then
+    elif [ $(which rpm >/dev/null) ]; then
         # If RPM based
         NEWEST_KERNEL=$(_get_newest_kernel_rhel)
     fi
 
     # Make sure that kernel name that we extracted corresponds to an installed
     # kernel
-    if [ -n "$NEWEST_KERNEL" ] && [ `_is_kernel_name_correct $NEWEST_KERNEL` = "no" ]; then
+    if [ -n "$NEWEST_KERNEL" ] && [ $(_is_kernel_name_correct $NEWEST_KERNEL) = "no" ]; then
         NEWEST_KERNEL=
     fi
 
@@ -156,7 +156,7 @@ elif [ -d "/usr/src/$NAME-$VERSION" ]; then
 fi
 
 # On 1st installation, let us look for a directory
-# in /lib/modules which matches `uname -r`. If none
+# in /lib/modules which matches $(uname -r). If none
 # is found it is possible that buildd is being used
 # and that uname -r is giving us the name of the
 # kernel used by the buildd machine.
@@ -178,7 +178,7 @@ NEWEST_KERNEL=$(get_newest_kernel)
 
 if [ -z "$autoinstall_all_kernels" ]; then
     # If the current kernel is installed on the system or chroot
-    if [ `_is_kernel_name_correct $CURRENT_KERNEL` = "yes" ]; then
+    if [ $(_is_kernel_name_correct $CURRENT_KERNEL) = "yes" ]; then
         if [ -n "$NEWEST_KERNEL" ] && [ ${CURRENT_KERNEL} != ${NEWEST_KERNEL} ]; then
             KERNELS="$CURRENT_KERNEL $NEWEST_KERNEL"
         else
@@ -216,8 +216,8 @@ if [ -n "$ARCH" ]; then
 fi
 
 for KERNEL in $KERNELS; do
-    dkms_status=`dkms status -m $NAME -v $VERSION -k $KERNEL $ARCH`
-    if [ `echo $KERNEL | grep -c "BOOT"` -gt 0 ]; then
+    dkms_status=$(dkms status -m $NAME -v $VERSION -k $KERNEL $ARCH)
+    if [ $(echo $KERNEL | grep -c "BOOT") -gt 0 ]; then
         echo ""
         echo "Module build and install for $KERNEL was skipped as "
         echo "it is a BOOT variant"
@@ -226,7 +226,7 @@ for KERNEL in $KERNELS; do
 
 
     #if the module isn't yet built, try to build it
-    if [ `echo $dkms_status | grep -c ": built"` -eq 0 ]; then
+    if [ $(echo $dkms_status | grep -c ": built") -eq 0 ]; then
         if [ ! -L /var/lib/dkms/$NAME/$VERSION/source ]; then
             echo "This package appears to be a binaries-only package"
             echo " you will not be able to build against kernel $KERNEL"
@@ -251,7 +251,7 @@ for KERNEL in $KERNELS; do
                 exit $?
                 ;;
             esac
-            dkms_status=`dkms status -m $NAME -v $VERSION -k $KERNEL $ARCH`
+            dkms_status=$(dkms status -m $NAME -v $VERSION -k $KERNEL $ARCH)
         else
             echo "Module build for kernel $KERNEL was skipped since the"
             echo "kernel headers for this kernel does not seem to be installed."
@@ -259,8 +259,8 @@ for KERNEL in $KERNELS; do
     fi
 
     #if the module is built (either pre-built or just now), install it
-    if [ `echo $dkms_status | grep -c ": built"` -eq 1 ] &&
-       [ `echo $dkms_status | grep -c ": installed"` -eq 0 ]; then
+    if [ $(echo $dkms_status | grep -c ": built") -eq 1 ] &&
+       [ $(echo $dkms_status | grep -c ": installed") -eq 0 ]; then
         dkms install -m $NAME -v $VERSION -k $KERNEL $ARCH
     fi
 done

--- a/lsb_release
+++ b/lsb_release
@@ -102,7 +102,7 @@ DESCSTR_DELI="release"
 
 # Display Program Version for internal use (needed by help2man)
 DisplayProgramVersion() { 
-    echo "FSG `basename $0` v$SCRIPTVERSION"
+    echo "FSG $(basename $0) v$SCRIPTVERSION"
     echo
     echo "Copyright (C) 2000, 2002, 2004 Free Standards Group, Inc."
     echo "This is free software; see the source for copying conditions.  There\
@@ -117,11 +117,11 @@ DisplayProgramVersion() {
 
 # defines the Usage for lsb_release
 Usage() {
-    echo "FSG `basename $0` v$SCRIPTVERSION prints certain LSB (Linux\
+    echo "FSG $(basename $0) v$SCRIPTVERSION prints certain LSB (Linux\
  Standard Base) and"
     echo "Distribution information."
     echo
-    echo "Usage: `basename $0` [OPTION]..."
+    echo "Usage: $(basename $0) [OPTION]..."
     echo "With no OPTION specified defaults to -v."
     echo
     echo "Options:"
@@ -193,7 +193,7 @@ GetLSBInfo() {
 	then
 	    for tag in "$INFO_ROOT/$INFO_LSB_DIR/"*
 	    do
-		LSB_VERSION=$LSB_VERSION:`basename $tag`
+		LSB_VERSION=$LSB_VERSION:$(basename $tag)
 	    done
 	fi
 }


### PR DESCRIPTION
In the same style as https://github.com/dell/dkms/commit/5d35dd150d315d25ef8f6f15b64ffcd444869db6 and https://github.com/dell/dkms/commit/3aafbbb6485f059c9160cb9f8681b3db92974e18, this removes the legacy backtick syntax in favor of `$()`