### PR TITLE
dkms.in: Handle error cases in autoinstall

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -2186,9 +2186,10 @@ autoinstall() {
         for mv in "${to_install[@]}"; do
             IFS=/ read m v <<< "$mv"
             if [[ -z "${build_depends[$m]}" ]]; then
-                (module="$m" module_version="$v" kernelver="$kernelver" arch="$arch" install_module)
-                installed_modules[${#installed_modules[@]}]="$m"
-                install_count=$(($install_count +1))
+                if (module="$m" module_version="$v" kernelver="$kernelver" arch="$arch" install_module); then
+                    installed_modules[${#installed_modules[@]}]="$m"
+                    install_count=$(($install_count +1))
+                fi
             else
                 next_install[${#next_install[@]}]="$mv"
             fi
@@ -2196,13 +2197,13 @@ autoinstall() {
 
         wait
 
-        # Step 3: Keep going if at least one module was installed during
+        # Step 3: Remove modules that install was attempted for
+        # during Step 2 from the job queue.
+        to_install=( "${next_install[@]}" )
+
+        # Step 4: Keep going if at least one module was installed during
         # this iteration.
         [[ "$install_count" -gt 0 ]] || break;
-
-        # Step 4: Remove modules that were installed during Step 2 from
-        # the job queue.
-        to_install=( "${next_install[@]}" )
 
     done
     for mv in "${to_install[@]}"; do

--- a/dkms.in
+++ b/dkms.in
@@ -2118,6 +2118,7 @@ autoinstall() {
     local -a to_install=()
     local -a next_install=()
     local -a installed_modules=()
+    local -a failed_modules=()
     local -A build_depends=()
 
     # Walk through our list of installed and built modules, and create
@@ -2189,6 +2190,8 @@ autoinstall() {
                 if (module="$m" module_version="$v" kernelver="$kernelver" arch="$arch" install_module); then
                     installed_modules[${#installed_modules[@]}]="$m"
                     install_count=$(($install_count +1))
+                else
+                    failed_modules=[${#failed_modules[@]}]="$m"
                 fi
             else
                 next_install[${#next_install[@]}]="$mv"
@@ -2210,6 +2213,11 @@ autoinstall() {
         IFS=/ read m v <<< "$mv"
         echo "$m/$v autoinstall failed due to missing dependencies: ${build_depends[$m]}"
     done
+
+    if [[ "${#failed_modules[@]}" > 0 || "${#to_install[@]}" > 0 ]]; then
+        die 11 $"One or more modules failed to install during autoinstall." \
+            $"Refer to previous errors for more information."
+    fi
 }
 
 #############################

--- a/run_test.sh
+++ b/run_test.sh
@@ -143,6 +143,8 @@ genericize_expected_output() {
     # OpenSSL non-critical errors while signing. Remove them to be more generic
     sed '/^At main.c:/d' -i ${output_log}
     sed '/^- SSL error:/d' -i ${output_log}
+    # Apport related error that can occur in the CI. Drop from the output to be more generic
+    sed "/^python3: can't open file '\/usr\/share\/apport\/package-hooks\/dkms_packages.py'\: \[Errno 2\] No such file or directory$/d" -i ${output_log}
 }
 
 run_with_expected_output() {

--- a/test/dkms_dependencies_test-1.0/Makefile
+++ b/test/dkms_dependencies_test-1.0/Makefile
@@ -1,0 +1,3 @@
+all:
+    @echo ERROR: This module should never build.
+    @exit 1

--- a/test/dkms_dependencies_test-1.0/dkms.conf
+++ b/test/dkms_dependencies_test-1.0/dkms.conf
@@ -1,0 +1,12 @@
+
+PACKAGE_NAME="dkms_dependencies_test"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME="dkms_dependencies_test"
+
+BUILD_DEPENDS="dkms_failing_test"
+
+MAKE="make all"
+
+AUTOINSTALL="yes"
+
+DEST_MODULE_LOCATION="/kernel/extra"

--- a/test/dkms_failing_test-1.0/Makefile
+++ b/test/dkms_failing_test-1.0/Makefile
@@ -1,0 +1,3 @@
+all:
+    @echo ERROR: This module fails to build.
+    @exit 1"

--- a/test/dkms_failing_test-1.0/dkms.conf
+++ b/test/dkms_failing_test-1.0/dkms.conf
@@ -1,0 +1,10 @@
+
+PACKAGE_NAME="dkms_failing_test"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME="dkms_failing_test"
+
+MAKE="make all"
+
+AUTOINSTALL="yes"
+
+DEST_MODULE_LOCATION="/kernel/extra"


### PR DESCRIPTION
Currently, autoinstall has two issues with error handling:
1. If a module fails to install, the log still acts as though it installed and continues with that assumption.
2. If any module fails to install or isn't installed, the exit code is still 0 and indicates success.

These two commits correct these behaviors to reflect the actual errors that occur.

## Testing:
Ran locally and confirmed the error cases are now handled.