### PR TITLE
Fix using PKCS#11 engine as private key

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -916,11 +916,12 @@ prepare_signing()
     fi
     echo "Public certificate (MOK): $mok_certificate"
 
-    if ( [ ! -f $mok_signing_key ] && [[ ! "$mok_signing_key" == *":"* ]] ) || [ ! -f $mok_certificate ]; then
+    # scripts/sign-file.c in kernel source also supports using "pkcs11:..." as private key
+    if [[ "$mok_signing_key" != "pkcs11:"* ]] && ( [ ! -f "$mok_signing_key" ] || [ ! -f "$mok_certificate" ] ); then
         echo "Certificate or key are missing, generating self signed certificate for MOK..."
         openssl req -new -x509 -nodes -days 36500 -subj "/CN=DKMS module signing key" \
-            -newkey rsa:2048 -keyout $mok_signing_key \
-            -outform DER -out $mok_certificate > /dev/null 2>&1
+            -newkey rsa:2048 -keyout "$mok_signing_key" \
+            -outform DER -out "$mok_certificate" > /dev/null 2>&1
     fi
 
     do_signing=1

--- a/dkms_framework.conf
+++ b/dkms_framework.conf
@@ -28,7 +28,10 @@
 # Location of the sign-file kernel binary (default: depends on distribution):
 # sign_file="/path/to/sign-file"
 
-# Location of the key and certificate used for Secure boot (default: /var/lib/dkms):
+# Location of the key and certificate files used for Secure boot.
+# mok_signing_key can also be a "pkcs11:..." string for PKCS#11 engine, as
+# long as the sign_file program supports it.
+# (default: /var/lib/dkms):
 # mok_signing_key=/var/lib/dkms/mok.key
 # mok_certificate=/var/lib/dkms/mok.pub
 


### PR DESCRIPTION
1. sign-file supports ```pkcs11:*```, not ```*:*```
2. openssl don't support using ```pkcs11:*``` for the -keyout argument