### PR TITLE
Update test script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       image: docker://docker.io/library/${{ matrix.distro.name }}:${{ matrix.distro.tag }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Alpine dependencies
       if: matrix.distro.name == 'alpine'
@@ -97,7 +97,7 @@ jobs:
 
     - name: Run tests
       run: |
-        if [ "${{ matrix.distro.name }}" = alpine ]; then
+        if [ "${{ matrix.distro.name }}" = alpine ] && ([ "${{ matrix.distro.tag }}" = 3.10 ] || [ "${{ matrix.distro.variant }}" = "-lts" ]); then
             ./run_test.sh --no-signing-tool
         elif [ "${{ matrix.distro.name }}" = debian ] && [ "${{ matrix.distro.tag }}" = 8 ]; then
             ./run_test.sh --no-signing-tool
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-${{ matrix.version }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
1. [Upgrade action version to v3 to get rid of the "Node.js 12 actions are deprecated." warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).
2. sign-file is available on certain alpine platforms. Enable signing test on those platforms.
3. Remove -e in shebang line. There is already ```set -eu``` below.
4. Only remove created files at beginning of the script. Check the existence of them at the end.