### PR TITLE
Verify the key of module signature in tests

### DIFF
--- a/test/framework/temp_key_cert.conf
+++ b/test/framework/temp_key_cert.conf
@@ -1,0 +1,2 @@
+mok_signing_key="/tmp/dkms_test_private_key"
+mok_certificate="/tmp/dkms_test_certificate"


### PR DESCRIPTION
Not only check whether the module has a signature, but also check whether the signature corresponds to the specified certificate