### PR TITLE
Ensure the kconfig file location is set during building

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -970,8 +970,6 @@ prepare_build()
     # If the module has not been added, try to add it.
     is_module_added "$module" "$module_version" || add_module
 
-    set_kernel_source_dir_and_kconfig "$kernelver"
-
     local -r base_dir="$dkms_tree/$module/$module_version/$kernelver/$arch"
     local -r build_dir="$dkms_tree/$module/$module_version/build"
     local -r source_dir="$dkms_tree/$module/$module_version/source"
@@ -1100,6 +1098,7 @@ clean_build()
 
 do_build()
 {
+    set_kernel_source_dir_and_kconfig "$kernelver"
     prepare_signing
     prepare_build
     actual_build


### PR DESCRIPTION
#266 is not fully fixed by #274. This is because the variable `kernel_config` is not set before calling `prepare_signing` if the module was not built before.

Fix #266.

