### PR TITLE
Upstream pull request incorrectly drops enroll-key option

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -920,6 +920,7 @@ prepare_signing()
                     fi
                     echo "Certificate or key are missing, generating them using update-secureboot-policy..."
                     SHIM_NOTRIGGER=y update-secureboot-policy --new-key &>/dev/null
+		    update-secureboot-policy --enroll-key
                 fi
 
                 ;;


### PR DESCRIPTION
When a brand new secureboot key is created, and it hasn't been previously enrolled as a mok key, it will be rejected by the kernel. After creating a new key, one should be enrolling it.