### PR TITLE
Fix warnings for modules with no version

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -690,10 +690,6 @@ compare_module_version()
 {
     readarray -t ver1 <<< "$(get_module_verinfo "$1")"
     readarray -t ver2 <<< "$(get_module_verinfo "$2")"
-    if [[ ! "$ver1" ]] || [[ ! "$ver2" ]]; then
-        echo "?"
-        return 1
-    fi
     if [[ "${ver1[0]}" = "${ver2[0]}" ]]; then
         if [[ "${ver1[1]}" = "${ver2[1]}" ]]; then
             echo "=="
@@ -701,6 +697,8 @@ compare_module_version()
             echo "="
         fi
         return 0
+    elif [[ ! "$ver1" ]] || [[ ! "$ver2" ]]; then
+        echo "?"
     elif [[ "$(VER "${ver1[0]}")" > "$(VER "${ver2[0]}")" ]]; then
         echo ">"
     else

--- a/test/dkms_emptyver_test/Makefile
+++ b/test/dkms_emptyver_test/Makefile
@@ -1,0 +1,7 @@
+obj-m += dkms_emptyver_test.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/test/dkms_emptyver_test/dkms.conf
+++ b/test/dkms_emptyver_test/dkms.conf
@@ -1,0 +1,12 @@
+
+PACKAGE_NAME="dkms_emptyver_test"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME="dkms_emptyver_test"
+
+# MAKE="make -C /lib/modules/${kernelver}/build SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
+# CLEAN="make -C /lib/modules/${kernelver}/build SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build  M=$PWD clean"
+
+AUTOINSTALL="yes"
+
+DEST_MODULE_LOCATION="/kernel/extra"
+

--- a/test/dkms_emptyver_test/dkms_emptyver_test.c
+++ b/test/dkms_emptyver_test/dkms_emptyver_test.c
@@ -1,0 +1,21 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("A Simple dkms test module with empty version");
+
+static int __init dkms_test_init(void)
+{
+    printk(KERN_INFO "DKMS Test Module - Loaded\n");
+    return 0;
+}
+
+static void __exit dkms_test_cleanup(void)
+{
+    printk(KERN_INFO "Cleaning up after dkms test module.\n");
+}
+
+module_init(dkms_test_init);
+module_exit(dkms_test_cleanup);
+MODULE_VERSION("");

--- a/test/dkms_nover_test/Makefile
+++ b/test/dkms_nover_test/Makefile
@@ -1,0 +1,7 @@
+obj-m += dkms_nover_test.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/test/dkms_nover_test/dkms.conf
+++ b/test/dkms_nover_test/dkms.conf
@@ -1,0 +1,12 @@
+
+PACKAGE_NAME="dkms_nover_test"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME="dkms_nover_test"
+
+# MAKE="make -C /lib/modules/${kernelver}/build SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
+# CLEAN="make -C /lib/modules/${kernelver}/build SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build  M=$PWD clean"
+
+AUTOINSTALL="yes"
+
+DEST_MODULE_LOCATION="/kernel/extra"
+

--- a/test/dkms_nover_test/dkms_nover_test.c
+++ b/test/dkms_nover_test/dkms_nover_test.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("A Simple dkms test module with no version");
+
+static int __init dkms_test_init(void)
+{
+    printk(KERN_INFO "DKMS Test Module - Loaded\n");
+    return 0;
+}
+
+static void __exit dkms_test_cleanup(void)
+{
+    printk(KERN_INFO "Cleaning up after dkms test module.\n");
+}
+
+module_init(dkms_test_init);
+module_exit(dkms_test_cleanup);


### PR DESCRIPTION
If there is no `MODULE_VERSION()` macro used in a module's source code, `modinfo` will not show the `version: xxxx` field for the compiled binary. 

if `MODULE_VERSION("")` is used, the situation is similar. `modinfo` will only show `version:` for the compiled binary. 

In both cases, `dkms status` will report `WARNING! Diff between built and installed module!` and `dkms uninstall` will say `Module was not found within /lib/modules/$kernelver/` and the the module will not be removed.

Fix #290
`