### PR TITLE
Fix building with clang and lld

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1036,8 +1036,8 @@ prepare_build()
             $"Check $build_dir for more information."
     done
 
-    if [[ -e $kernel_source_dir/.config ]]; then
-        cc=$(sed -n 's|^CONFIG_CC_VERSION_TEXT="\([^ ]*\) .*"|\1|p' $kernel_source_dir/.config)
+    if [[ -e "${kernel_config}" ]]; then
+        cc=$(sed -n 's|^CONFIG_CC_VERSION_TEXT="\([^ ]*\) .*"|\1|p' "${kernel_config}")
         if command -v "$cc" >/dev/null; then
             export CC="$cc"
         fi

--- a/dkms.in
+++ b/dkms.in
@@ -1040,6 +1040,7 @@ prepare_build()
         cc=$(sed -n 's|^CONFIG_CC_VERSION_TEXT="\([^ ]*\) .*"|\1|p' "${kernel_config}")
         if command -v "$cc" >/dev/null; then
             export CC="$cc"
+            export KERNEL_CC="$cc"
         fi
     fi
 

--- a/dkms.in
+++ b/dkms.in
@@ -1038,7 +1038,7 @@ prepare_build()
 
     if [[ -e "${kernel_config}" ]]; then
         if grep -q 'CONFIG_CC_IS_CLANG=y' "${kernel_config}"; then
-            cc=clang
+            local cc=clang
             if command -v "$cc" >/dev/null; then
                 export CC="$cc"
                 export KERNEL_CC="$cc"
@@ -1046,7 +1046,7 @@ prepare_build()
         fi
 
         if grep -q 'CONFIG_LD_IS_LLD=y' "${kernel_config}"; then
-            ld=ld.lld
+            local ld=ld.lld
             if command -v "$ld" >/dev/null; then
                 export LD="$ld"
                 export KERNEL_LD="$ld"

--- a/dkms.in
+++ b/dkms.in
@@ -1037,10 +1037,12 @@ prepare_build()
     done
 
     if [[ -e "${kernel_config}" ]]; then
-        cc=$(sed -n 's|^CONFIG_CC_VERSION_TEXT="\([^ ]*\) .*"|\1|p' "${kernel_config}")
-        if command -v "$cc" >/dev/null; then
-            export CC="$cc"
-            export KERNEL_CC="$cc"
+        if grep -q 'CONFIG_CC_IS_CLANG=y' "${kernel_config}"; then
+            cc=clang
+            if command -v "$cc" >/dev/null; then
+                export CC="$cc"
+                export KERNEL_CC="$cc"
+            fi
         fi
 
         if grep -q 'CONFIG_LD_IS_LLD=y' "${kernel_config}"; then

--- a/dkms.in
+++ b/dkms.in
@@ -1042,6 +1042,14 @@ prepare_build()
             export CC="$cc"
             export KERNEL_CC="$cc"
         fi
+
+        if grep -q 'CONFIG_LD_IS_LLD=y' "${kernel_config}"; then
+            ld=ld.lld
+            if command -v "$ld" >/dev/null; then
+                export LD="$ld"
+                export KERNEL_LD="$ld"
+            fi
+        fi
     fi
 
     # Run the pre_build script


### PR DESCRIPTION
when building zfs dkms module it fails because KERNEL_CC and KERNEL_LD wasn't set correctly