### PR TITLE
man: reinstate NO_WEAK_MODULES section

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -542,6 +542,17 @@ DEST_MODULE_LOCATION[1]="/kernel/drivers/other/").
 DEST_MODULE_LOCATION is ignored on Fedora and Red Hat Enterprise Linux, Novell SuSE Linux Enterprise Server 10
 and higher, Novell SuSE Linux 10.0 and higher, and Ubuntu. Instead, the proper distribution-specific directory is used.
 .TP
+.B NO_WEAK_MODULES=
+The
+.B NO_WEAK_MODULES
+parameter prevents dkms from creating a symlink into the weak-updates directory, which is the
+default on Red Hat derivatives. The weak modules facility was designed to eliminate the need to
+rebuild kernel modules when kernel upgrades occur and relies on the symbols within the kABI.
+
+Fedora does not guaranteed a stable kABI so it should be disabled in the specific module override by setting it to "yes". For example, for an Nvidia DKMS module you would set the following in /etc/dkms/nvidia.conf:
+
+NO_WEAK_MODULES="yes"
+.TP
 .B STRIP[#]=
 By default strip is considered to be "yes". If set to "no", DKMS will not
 run strip \-g against your built module to remove debug symbols from it.


### PR DESCRIPTION
The documentation was dropped, even though the functionality is still there... oops

Closes: https://github.com/dell/dkms/issues/304
Fixes: 961f9ce ("dkms: deprecate initrd and modules.conf handling")