### PR TITLE
dkms: skip module signing when hash is unknown

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
       run: |
         if [ "${{ matrix.distro.name }}" = alpine ] && ([ "${{ matrix.distro.tag }}" = 3.10 ] || [ "${{ matrix.distro.variant }}" = "-lts" ]); then
             ./run_test.sh --no-signing-tool
-        elif [ "${{ matrix.distro.name }}" = debian ] && [ "${{ matrix.distro.tag }}" = 8 ]; then
+        elif [ "${{ matrix.distro.name }}" = debian ] && ([ "${{ matrix.distro.tag }}" = 8 ] || [ "${{ matrix.distro.tag }}" = 9 ]); then
             ./run_test.sh --no-signing-tool
         else
             ./run_test.sh

--- a/dkms.in
+++ b/dkms.in
@@ -905,6 +905,14 @@ prepare_signing()
 {
     do_signing=0
 
+    if [[ -f "${kernel_config}" ]]; then
+        sign_hash="$(grep "^CONFIG_MODULE_SIG_HASH=" "${kernel_config}" | sed 's/CONFIG_MODULE_SIG_HASH=//;s/"//g')"
+        # The kernel may be built without module signing facility. CONFIG_MODULE_SIG_HASH is unset in kconfig
+        sign_hash="${sign_hash:-sha512}"
+    else
+        sign_hash="sha512"
+    fi
+
     # Lazy source in signing related configuration
     read_framework_conf $dkms_framework_signing_variables
 
@@ -981,14 +989,6 @@ prepare_signing()
     if [ ! -f "${mok_certificate}" ]; then
         echo "Certificate file ${mok_certificate} not found and can't be generated, modules won't be signed"
         return
-    fi
-
-    if [[ -f "${kernel_config}" ]]; then
-        sign_hash="$(grep "^CONFIG_MODULE_SIG_HASH=" "${kernel_config}" | sed 's/CONFIG_MODULE_SIG_HASH=//;s/"//g')"
-        # The kernel may be built without module signing facility. CONFIG_MODULE_SIG_HASH is unset in kconfig
-        sign_hash="${sign_hash:-sha512}"
-    else
-        sign_hash="sha512"
     fi
 
     do_signing=1

--- a/dkms.in
+++ b/dkms.in
@@ -905,13 +905,17 @@ prepare_signing()
 {
     do_signing=0
 
-    if [[ -f "${kernel_config}" ]]; then
-        sign_hash="$(grep "^CONFIG_MODULE_SIG_HASH=" "${kernel_config}" | sed 's/CONFIG_MODULE_SIG_HASH=//;s/"//g')"
-        # The kernel may be built without module signing facility. CONFIG_MODULE_SIG_HASH is unset in kconfig
-        sign_hash="${sign_hash:-sha512}"
-    else
-        sign_hash="sha512"
+    if [[ ! -f "${kernel_config}" ]]; then
+        echo "Kernel config ${kernel_config} not found, modules won't be signed"
+        return
     fi
+
+    if ! grep -q "^CONFIG_MODULE_SIG_HASH=" "${kernel_config}"; then
+        echo "The kernel is be built without module signing facility, modules won't be signed"
+        return
+    fi
+
+    sign_hash=$(grep "^CONFIG_MODULE_SIG_HASH=" "${kernel_config}" | cut -f2 -d= | sed 's/"//g')
 
     # Lazy source in signing related configuration
     read_framework_conf $dkms_framework_signing_variables

--- a/dkms.in
+++ b/dkms.in
@@ -903,6 +903,8 @@ prepare_kernel()
 
 prepare_signing()
 {
+    do_signing=0
+
     # Lazy source in signing related configuration
     read_framework_conf $dkms_framework_signing_variables
 
@@ -1113,7 +1115,7 @@ actual_build()
 
         [[ ${strip[$count]} != no ]] && strip -g "$built_module"
 
-        if [ -n "${do_signing}" ]; then
+        if (( do_signing )); then
             echo "Signing module $built_module"
             "$sign_file" "$sign_hash" "$mok_signing_key" "$mok_certificate" "$built_module"
         fi

--- a/run_test.sh
+++ b/run_test.sh
@@ -46,6 +46,7 @@ TEST_TMPFILES=(
 )
 
 SIGNING_MESSAGE=""
+declare -i NO_SIGNING_TOOL
 if [ "$#" = 1 ] && [ "$1" = "--no-signing-tool" ]; then
     echo 'Ignore signing tool errors'
     NO_SIGNING_TOOL=1
@@ -124,7 +125,7 @@ set_signing_message() {
     # $1: module name
     # $2: module version
     # $3: module file name if not the same as $1
-    if [[ "$NO_SIGNING_TOOL" = 0 ]]; then
+    if (( NO_SIGNING_TOOL == 0 )); then
         SIGNING_MESSAGE="Signing module /var/lib/dkms/$1/$2/build/${3:-$1}.ko"$'\n'
     fi
 }
@@ -165,7 +166,7 @@ genericize_expected_output() {
     sed -i '/^Public certificate (MOK):/d' ${output_log}
     sed -i '/^Certificate or key are missing, generating them using update-secureboot-policy...$/d' ${output_log}
     sed -i '/^Certificate or key are missing, generating self signed certificate for MOK...$/d' ${output_log}
-    if [[ "${NO_SIGNING_TOOL}" = "1" ]]; then
+    if (( NO_SIGNING_TOOL == 1 )); then
         sed -i "/^The kernel is be built without module signing facility, modules won't be signed$/d" ${output_log}
         sed -i "/^Binary .* not found, modules won't be signed$/d" ${output_log}
         # Uncomment the following line to run this script with --no-signing-tool on platforms where the sign-file tool exists
@@ -323,7 +324,7 @@ run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, $(uname -m): built
 EOF
 
-if [[ "${NO_SIGNING_TOOL}" = 0 ]]; then
+if (( NO_SIGNING_TOOL == 0 )); then
     echo 'Building the test module with bad sign_file path in framework file'
     cp test/framework/bad_sign_file_path.conf /etc/dkms/framework.conf.d/dkms_test_framework.conf
     run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
@@ -417,7 +418,7 @@ run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, $(uname -m): built
 EOF
 
-if [[ "${NO_SIGNING_TOOL}" = 0 ]]; then
+if (( NO_SIGNING_TOOL == 0 )); then
     echo 'Extracting serial number from the certificate'
     MODULE_SERIAL="$(cert_serial /tmp/dkms_test_certificate)"
 fi
@@ -482,7 +483,7 @@ description:    A Simple dkms test module
 license:        GPL
 EOF
 
-if [[ "${NO_SIGNING_TOOL}" = 0 ]]; then
+if (( NO_SIGNING_TOOL == 0 )); then
     echo 'Checking module signature'
     SIG_KEY="$(modinfo -F sig_key "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}" | tr -d ':')"
     SIG_HASH="$(modinfo -F sig_hashalgo "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}")"
@@ -607,7 +608,7 @@ description:    A Simple dkms test module
 license:        GPL
 EOF
 
-if [[ "${NO_SIGNING_TOOL}" = 0 ]]; then
+if (( NO_SIGNING_TOOL == 0 )); then
     echo 'Checking module signature'
     SIG_KEY="$(modinfo -F sig_key "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}" | tr -d ':')"
     SIG_HASH="$(modinfo -F sig_hashalgo "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}")"
@@ -692,7 +693,7 @@ run_status_with_expected_output 'dkms_test' << EOF
 EOF
 
 echo 'Removing temporary files'
-if [[ "${NO_SIGNING_TOOL}" = 0 ]]; then
+if (( NO_SIGNING_TOOL == 0 )); then
     rm /tmp/dkms_test_private_key /tmp/dkms_test_certificate
 fi
 rm /etc/dkms/framework.conf.d/dkms_test_framework.conf

--- a/run_test.sh
+++ b/run_test.sh
@@ -166,6 +166,7 @@ genericize_expected_output() {
     sed -i '/^Certificate or key are missing, generating them using update-secureboot-policy...$/d' ${output_log}
     sed -i '/^Certificate or key are missing, generating self signed certificate for MOK...$/d' ${output_log}
     if [[ "${NO_SIGNING_TOOL}" = "1" ]]; then
+        sed -i "/^The kernel is be built without module signing facility, modules won't be signed$/d" ${output_log}
         sed -i "/^Binary .* not found, modules won't be signed$/d" ${output_log}
         # Uncomment the following line to run this script with --no-signing-tool on platforms where the sign-file tool exists
         # sed -i '/^Signing module \/var\/lib\/dkms\/dkms_test\/1.0\/build\/dkms_test.ko$/d' ${output_log}

--- a/run_test.sh
+++ b/run_test.sh
@@ -161,12 +161,13 @@ genericize_expected_output() {
         sed -i '/^depmod\.\.\.$/d' ${output_log}
     fi
     # Signing related output. Drop it from the output, to be more generic
-    sed -i '/^Sign command:/d' ${output_log}
-    sed -i '/^Signing key:/d' ${output_log}
-    sed -i '/^Public certificate (MOK):/d' ${output_log}
-    sed -i '/^Certificate or key are missing, generating them using update-secureboot-policy...$/d' ${output_log}
-    sed -i '/^Certificate or key are missing, generating self signed certificate for MOK...$/d' ${output_log}
-    if (( NO_SIGNING_TOOL == 1 )); then
+    if (( NO_SIGNING_TOOL == 0 )); then
+        sed -i '/^Sign command:/d' ${output_log}
+        sed -i '/^Signing key:/d' ${output_log}
+        sed -i '/^Public certificate (MOK):/d' ${output_log}
+        sed -i '/^Certificate or key are missing, generating them using update-secureboot-policy...$/d' ${output_log}
+        sed -i '/^Certificate or key are missing, generating self signed certificate for MOK...$/d' ${output_log}
+    else
         sed -i "/^The kernel is be built without module signing facility, modules won't be signed$/d" ${output_log}
         sed -i "/^Binary .* not found, modules won't be signed$/d" ${output_log}
         # Uncomment the following line to run this script with --no-signing-tool on platforms where the sign-file tool exists


### PR DESCRIPTION
Currently we'll attempt to sign the modules, even when we don't have the
kernel config and/or when CONFIG_MODULE_SIG_HASH is not set.

This serves little purpose, since in either of those cases the kernel
won't check the signature.

As [mentioned previously](https://github.com/dell/dkms/issues/305#issuecomment-1445943045)

@xuzhen please give this a once-over. I suspect that some tests may fail, because we duck-tap (read workarounds) which need updateing 