### PR TITLE
CI: remove Debian 8 from the build matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,6 @@ jobs:
           - {name: "debian", tag: "11"}
           - {name: "debian", tag: "10"}
           - {name: "debian", tag: "9"}
-          - {name: "debian", tag: "8"}
           - {name: "ubuntu", tag: "22.04"}
           - {name: "ubuntu", tag: "20.04"}
           - {name: "ubuntu", tag: "18.04"}
@@ -66,13 +65,8 @@ jobs:
     - name: Install Debian dependencies
       if: matrix.distro.name == 'debian'
       run: |
-        EXTRA_ARGS=''
-        if [ "${{ matrix.distro.tag }}" = 8 ] ; then
-            # repo key is expired
-            EXTRA_ARGS="--allow-unauthenticated"
-        fi
         apt-get update -q
-        apt-get install -qy $EXTRA_ARGS gcc make linux-headers-amd64 linux-image-amd64 openssl
+        apt-get install -qy gcc make linux-headers-amd64 linux-image-amd64 openssl
 
     - name: Install Ubuntu dependencies
       if: matrix.distro.name == 'ubuntu'
@@ -109,7 +103,7 @@ jobs:
       run: |
         if [ "${{ matrix.distro.name }}" = alpine ] && ([ "${{ matrix.distro.tag }}" = 3.10 ] || [ "${{ matrix.distro.variant }}" = "-lts" ]); then
             ./run_test.sh --no-signing-tool
-        elif [ "${{ matrix.distro.name }}" = debian ] && ([ "${{ matrix.distro.tag }}" = 8 ] || [ "${{ matrix.distro.tag }}" = 9 ]); then
+        elif [ "${{ matrix.distro.name }}" = debian ] && [ "${{ matrix.distro.tag }}" = 9 ]; then
             ./run_test.sh --no-signing-tool
         else
             ./run_test.sh


### PR DESCRIPTION
Debian 8 was EOL circa July 2020, their repo keys have been expired for around three months now and as of a few days ago, the packages were moved from the official server(s).