### PR TITLE
CI: Update distros

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,8 @@ jobs:
           - {name: "archlinux", tag: "latest", variant: "-lts"}
           - {name: "archlinux", tag: "latest", variant: "-zen"}
           - {name: "centos", tag: "7"}
-          - {name: "almalinux", tag: "8"}
           - {name: "almalinux", tag: "9"}
+          - {name: "almalinux", tag: "8"}
           - {name: "debian", tag: "11"}
           - {name: "debian", tag: "10"}
           - {name: "debian", tag: "9"}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,16 +13,12 @@ jobs:
     strategy:
       matrix:
         distro:
-          - {name: "alpine", tag: "3.14", variant: "-lts"}
-          - {name: "alpine", tag: "3.14", variant: "-virt"}
-          - {name: "alpine", tag: "3.13", variant: "-lts"}
-          - {name: "alpine", tag: "3.13", variant: "-virt"}
-          - {name: "alpine", tag: "3.12", variant: "-lts"}
-          - {name: "alpine", tag: "3.12", variant: "-virt"}
-          - {name: "alpine", tag: "3.11", variant: "-lts"}
-          - {name: "alpine", tag: "3.11", variant: "-virt"}
-          - {name: "alpine", tag: "3.10", variant: "-vanilla"}
-          - {name: "alpine", tag: "3.10", variant: "-virt"}
+          - {name: "alpine", tag: "3.17", variant: "-lts"}
+          - {name: "alpine", tag: "3.17", variant: "-virt"}
+          - {name: "alpine", tag: "3.16", variant: "-lts"}
+          - {name: "alpine", tag: "3.16", variant: "-virt"}
+          - {name: "alpine", tag: "3.15", variant: "-lts"}
+          - {name: "alpine", tag: "3.15", variant: "-virt"}
           - {name: "archlinux", tag: "latest"}
           - {name: "archlinux", tag: "latest", variant: "-lts"}
           - {name: "archlinux", tag: "latest", variant: "-zen"}
@@ -101,7 +97,7 @@ jobs:
 
     - name: Run tests
       run: |
-        if [ "${{ matrix.distro.name }}" = alpine ] && ([ "${{ matrix.distro.tag }}" = 3.10 ] || [ "${{ matrix.distro.variant }}" = "-lts" ]); then
+        if [ "${{ matrix.distro.name }}" = alpine ] && [ "${{ matrix.distro.variant }}" = "-lts" ]; then
             ./run_test.sh --no-signing-tool
         elif [ "${{ matrix.distro.name }}" = debian ] && [ "${{ matrix.distro.tag }}" = 9 ]; then
             ./run_test.sh --no-signing-tool

--- a/run_test.sh
+++ b/run_test.sh
@@ -256,6 +256,7 @@ case "${os_id}" in
         ;;
     alpine)
         expected_dest_loc=kernel/extra
+        mod_compression_ext=.gz
         ;;
     *)
         echo >&2 "Error: unknown Linux distribution ID ${os_id}"


### PR DESCRIPTION
Going through the distributions list:
 - remove: Alpine 3.14 and earlier (3.14 is EOL next month)
 - add: Apline 3.15 - 3.17
 - keep: CentOS 7 is EOL no newer version officially has docker images (could be wrong here)
 - keep: Ubuntu 18.04 (EOL this month) - should we drop this @xnox @anbe42
 - keep: Debian 9 (EOL 2020, LTS 2022) - planning to keep until Debian 12 is released in a few months
 
 @xuzhen @scaronni should we add some Suse/Fedora/other versions in the mix?