### PR TITLE
dkms: reinstate --enroll-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ mok_certificate="/var/lib/shim-signed/mok/MOK.der"
 ```
 
 The paths specified in `mok_signing_key`, `mok_certificate` and `sign_file` can
-use the variable `${kernelver}` to represent the target kernel version. 
+use the variable `${kernelver}` to represent the target kernel version.
 ```
 sign_file="/lib/modules/${kernelver}/build/scripts/sign-file"
 ```
@@ -162,11 +162,13 @@ And confirm with "Yes" when prompted:
 
 ![Enroll the key(s)?](/images/mok-key-4.png)
 
-After this, enter the password you set up with `mokutil --import` in the previous step:
+After this, enter the password you set up with `mokutil --import` in the
+previous step:
 
 ![Enroll the key(s)?](/images/mok-key-5.png)
 
-At this point you are done, select "OK" and the computer will reboot trusting the key for your modules:
+At this point you are done, select "OK" and the computer will reboot trusting
+the key for your modules:
 
 ![Perform MOK management](/images/mok-key-6.png)
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ your own certificates of choice.
 
 The location as well can be changed by setting the appropriate variables in
 `/etc/dkms/framework.conf`. For example, to allow usage of the system default
-Debian and Ubuntu `update-secureboot-policy` set the configuration file as
-follows:
+Ubuntu `update-secureboot-policy` set the configuration file as follows:
 ```
 mok_signing_key="/var/lib/shim-signed/mok/MOK.priv"
 mok_certificate="/var/lib/shim-signed/mok/MOK.der"

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ the configured kernel compression mechanism of choice.
 This requires the `openssl` command to be present on the system.
 
 Private key and certificate are auto generated the first time DKMS is run and
-placed in `/var/lib/dkms`. These certificate files can be prepulated with your
-own certificates of choice.
+placed in `/var/lib/dkms`. These certificate files can be pre-populated with
+your own certificates of choice.
 
 The location as well can be changed by setting the appropriate variables in
-`/etc/dkms/framework.conf`. For example, to awllow usage of the system default
+`/etc/dkms/framework.conf`. For example, to allow usage of the system default
 Debian and Ubuntu `update-secureboot-policy` set the configuration file as
 follows:
 ```

--- a/dkms.in
+++ b/dkms.in
@@ -962,6 +962,7 @@ prepare_signing()
                     fi
                     echo "Certificate or key are missing, generating them using update-secureboot-policy..."
                     SHIM_NOTRIGGER=y update-secureboot-policy --new-key &>/dev/null
+                    update-secureboot-policy --enroll-key
                 fi
 
                 ;;

--- a/run_test.sh
+++ b/run_test.sh
@@ -166,6 +166,8 @@ genericize_expected_output() {
     fi
     # Signing related output. Drop it from the output, to be more generic
     if (( NO_SIGNING_TOOL == 0 )); then
+        sed -i '/^EFI variables are not supported on this system/d' ${output_log}
+        sed -i '/^\/sys\/firmware\/efi\/efivars not found, aborting./d' ${output_log}
         sed -i '/^Sign command:/d' ${output_log}
         sed -i '/^Signing key:/d' ${output_log}
         sed -i '/^Public certificate (MOK):/d' ${output_log}

--- a/run_test.sh
+++ b/run_test.sh
@@ -10,6 +10,10 @@ KERNEL_VER="${KERNEL_VER:-$(uname -r)}"
 KERNEL_ARCH="$(uname -m)"
 echo "Using kernel ${KERNEL_VER}/${KERNEL_ARCH}"
 
+# debconf can trigger at random points, in the testing process. Where a bunch of
+# the frontends cannot work in our CI. Just opt for the noninteractive one.
+export DEBIAN_FRONTEND=noninteractive
+
 # Avoid output variations due to parallelism
 export parallel_jobs=1
 


### PR DESCRIPTION
This is a Debian/Ubuntu patch, the following is their original commit message:

 When a brand new secureboot key is created, and it hasn't been
 previously enrolled as a mok key, it will be rejected by the
 kernel. After creating a new key, one should be enrolling it.

Side note: The update-secureboot-policy script seemingly originates from Ubuntu, where Debian has an ancient copy, which lacks both --new-key and --enroll-key.

Fixes: 3ca52f8 ("Fix signing on ubuntu & debian (#244)")

@xuzhen @anbe42 jfyi