### PR TITLE
CI: remove Debian 9 from the matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           - {name: "almalinux", tag: "8"}
           - {name: "debian", tag: "11"}
           - {name: "debian", tag: "10"}
-          - {name: "debian", tag: "9"}
           - {name: "ubuntu", tag: "22.04"}
           - {name: "ubuntu", tag: "20.04"}
           - {name: "ubuntu", tag: "18.04"}
@@ -98,8 +97,6 @@ jobs:
     - name: Run tests
       run: |
         if [ "${{ matrix.distro.name }}" = alpine ] && [ "${{ matrix.distro.variant }}" = "-lts" ]; then
-            ./run_test.sh --no-signing-tool
-        elif [ "${{ matrix.distro.name }}" = debian ] && [ "${{ matrix.distro.tag }}" = 9 ]; then
             ./run_test.sh --no-signing-tool
         else
             ./run_test.sh


### PR DESCRIPTION
The distribution has recently been archived and the packages are no longer reachable... In the default configuration at least - I didn't try rummaging through the apt config.

AFAICT Debian 9 has gone EOL in 2020, with LTS finishing in 2022. There is an ELTS still ongoing but that's outside of our concerns... Unless someone comes up with enticing suggestions that is ;-)

/cc @anbe42