### PR TITLE
Fix CC detection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       if: matrix.distro.name == 'debian'
       run: |
         apt-get update -q
-        apt-get install -qy gcc make linux-headers-amd64 linux-image-amd64 openssl
+        apt-get install -qy make linux-headers-amd64 linux-image-amd64 openssl
 
     - name: Install Ubuntu dependencies
       if: matrix.distro.name == 'ubuntu'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
           - {name: "centos", tag: "7"}
           - {name: "almalinux", tag: "9"}
           - {name: "almalinux", tag: "8"}
+          - {name: "debian", tag: "12"}
           - {name: "debian", tag: "11"}
           - {name: "debian", tag: "10"}
           - {name: "ubuntu", tag: "22.04"}

--- a/dkms.in
+++ b/dkms.in
@@ -1061,6 +1061,12 @@ prepare_build()
             $"Check $build_dir for more information."
     done
 
+    if [ -f "$kernel_source_dir/.kernelvariables" ]; then
+        export CC=$(echo -e "show-%:\n\t@echo \$(\$*)\ninclude $kernel_source_dir/.kernelvariables" | make -f - show-CC)
+    else
+        unset CC
+    fi
+
     if [[ -e "${kernel_config}" ]]; then
         local cc=$(sed -n 's|^CONFIG_CC_VERSION_TEXT="\([^ ]*\) .*"|\1|p' "${kernel_config}")
         if command -v "$cc" >/dev/null; then
@@ -1099,12 +1105,6 @@ actual_build()
 
     echo $""
     echo $"Building module:"
-
-    if [ -f "$kernel_source_dir/.kernelvariables" ]; then
-        export CC=$(echo -e "show-%:\n\t@echo \$(\$*)\ninclude $kernel_source_dir/.kernelvariables" | make -f - show-CC)
-    else
-        unset CC
-    fi
 
     invoke_command "$clean" "Cleaning build area" background
     echo $"DKMS make.log for $module-$module_version for kernel $kernelver ($arch)" >> "$build_log"

--- a/dkms.in
+++ b/dkms.in
@@ -287,6 +287,9 @@ setup_kernels_arches()
                 fi
             fi
         fi
+        if [[ ! $arch ]]; then
+            die 12 $"Could not determine architecture."
+        fi
     fi
 
     # If only one arch is specified, make it so for all the kernels

--- a/dkms.in
+++ b/dkms.in
@@ -1062,6 +1062,12 @@ prepare_build()
     done
 
     if [[ -e "${kernel_config}" ]]; then
+        local cc=$(sed -n 's|^CONFIG_CC_VERSION_TEXT="\([^ ]*\) .*"|\1|p' "${kernel_config}")
+        if command -v "$cc" >/dev/null; then
+            export CC="$cc"
+            export KERNEL_CC="$cc"
+        fi
+
         if grep -q 'CONFIG_CC_IS_CLANG=y' "${kernel_config}"; then
             local cc=clang
             if command -v "$cc" >/dev/null; then

--- a/run_test.sh
+++ b/run_test.sh
@@ -678,7 +678,7 @@ echo "Running dkms autoinstall for a kernel without headers installed (expected 
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}-noheaders" << EOF
 Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
 Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
-dkms autoinstall on ${KERNEL_VER}-noheaders/x86_64 failed for dkms_test(1)
+dkms autoinstall on ${KERNEL_VER}-noheaders/${KERNEL_ARCH} failed for dkms_test(1)
 Error! One or more modules failed to install during autoinstall.
 Refer to previous errors for more information.
 EOF


### PR DESCRIPTION
The recent clang detection improvements broke getting a non-clang compiler from the kernel config.
Also move .kernelvariables parsing to prepare_build() where the other CC handling is.
On Debian there is no need for gcc, the header package has the required compiler dependency.

We had an interesting bug report on Debian (https://bugs.debian.org/1036033) where a broken rpm shim caused weird errors in dkms after a module was added and built with an empty $arch. So error out early if $arch cannot be determined, before misplacing stuff in /var/lib/dkms.

PS: Debian 12 (bookworm) was released yesterday, but there is no container image, yet, otherwise I would have added that to the matrix.
