### PR TITLE
Makefile: fix extension of kernel-install plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ install: dkms dkms.8
 	mkdir -p $(ETC)/framework.conf.d
 	install -D -m 0644 dkms.bash-completion $(BASHDIR)/dkms
 	install -D -m 0644 dkms.8 $(MAN)/dkms.8
-	install -D -m 0755 kernel_install.d_dkms $(KCONF)/install.d/dkms
+	install -D -m 0755 kernel_install.d_dkms $(KCONF)/install.d/40-dkms.install
 	install -D -m 0755 kernel_postinst.d_dkms $(KCONF)/postinst.d/dkms
 	install -D -m 0755 kernel_prerm.d_dkms $(KCONF)/prerm.d/dkms
 	gzip -n -9 $(MAN)/dkms.8


### PR DESCRIPTION
According to the kernel-install manual plugins need to have the `.install` extension, otherwise they are ignored:

```
kernel-install will run the executable files ("plugins") located in the directory
/usr/lib/kernel/install.d/ and the local administration directory /etc/kernel/install.d/. All files
are collectively sorted and executed in lexical order, regardless of the directory in which they
live. However, files with identical filenames replace each other. Files in /etc/kernel/install.d/
take precedence over files with the same name in /usr/lib/kernel/install.d/. This can be used to
override a system-supplied executables with a local file if needed; a symbolic link in
/etc/kernel/install.d/ with the same name as an executable in /usr/lib/kernel/install.d/, pointing
to /dev/null, disables the executable entirely. Executables must have the extension ".install";
other extensions are ignored.
```