### PR TITLE
dkms: always use read_conf_or_die

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1731,7 +1731,7 @@ do_status_weak()
 # interested in, but that the DKMS internals do not usually care about.
 module_status_built_extra() (
     set_module_suffix "$3"
-    read_conf "$3" "$4" "$dkms_tree/$1/$2/source/dkms.conf" 2>/dev/null
+    read_conf_or_die "$3" "$4" "$dkms_tree/$1/$2/source/dkms.conf" 2>/dev/null
     [[ -d $dkms_tree/$1/original_module/$3/$4 ]] && echo -n " (original_module exists)"
     for ((count=0; count < ${#dest_module_name[@]}; count++)); do
         tree_mod=$(compressed_or_uncompressed "$dkms_tree/$1/$2/$3/$4/module" "${dest_module_name[$count]}")


### PR DESCRIPTION
Currently dkms status and by extension dkms autoinstall use read_conf, which prints an error yet results in the commands succeeding.

Browsing across Arch and Debian, this can only happen on user error. As such lets flip it to the fatal "_or_die" variant, like all the other instances in the codebase.

---

See https://github.com/dell/dkms/issues/352 for context.

/cc @scaronni @anbe42 @C0rn3j do shout if you think this is a bad idea, thanks in advance.