### PR TITLE
test: Make suite runnable on `linuxmint`

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -242,7 +242,7 @@ case "${os_id}" in
     sles | suse | opensuse)
         expected_dest_loc=updates
         ;;
-    arch | debian | ubuntu)
+    arch | debian | ubuntu | linuxmint)
         expected_dest_loc=updates/dkms
         ;;
     alpine)


### PR DESCRIPTION
I'm on Mint, and this was required to get the suite running when I was working on #351.
