### PR TITLE
Document that both MOK files must exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Ubuntu `update-secureboot-policy` set the configuration file as follows:
 mok_signing_key="/var/lib/shim-signed/mok/MOK.priv"
 mok_certificate="/var/lib/shim-signed/mok/MOK.der"
 ```
+NOTE: If any of the files specified by `mok_signing_key` and
+`mok_certificate` are non-existant, dkms will re-create both files.
 
 The paths specified in `mok_signing_key`, `mok_certificate` and `sign_file` can
 use the variable `${kernelver}` to represent the target kernel version.

--- a/dkms.8.in
+++ b/dkms.8.in
@@ -787,6 +787,10 @@ can be used in path to represent the target kernel version. The path for the bin
 Location of the key and certificate files used for Secure boot. The variable
 .B $kernelver
 can be used in path to represent the target kernel version.
+
+NOTE: If any of the files specified by $mok_signing_key and
+$mok_certificate are non-existant, dkms will re-create both files.
+
 .I mok_signing_key
 can also be a "pkcs11:..." string for PKCS#11 engine, as long as the sign_file program supports it.
 .TP

--- a/dkms_framework.conf
+++ b/dkms_framework.conf
@@ -31,6 +31,10 @@
 
 # Location of the key and certificate files used for Secure boot. $kernelver
 # can be used in path to represent the target kernel version.
+#
+# NOTE: If any of the files specified by `mok_signing_key` and
+# `mok_certificate` are non-existant, dkms will re-create both files.
+#
 # mok_signing_key can also be a "pkcs11:..." string for PKCS#11 engine, as
 # long as the sign_file program supports it.
 # (default: /var/lib/dkms):


### PR DESCRIPTION
... or dkms will overwrite them both.

In the future we might consider changing this to an error if only one of the two is available, but for now document the current behaviour.

Closes: https://github.com/dell/dkms/issues/366

/cc @anbe42 