### PR TITLE
Man page updates

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -323,6 +323,10 @@ and
 .B ldtarball
 to force copying over of extant files.
 .TP
+.B \-\-force\-version\-override
+This option skips the checks whether the version of the module, which is
+going to be installed, is newer than the already installed version.
+.TP
 .B \-\-binaries\-only
 This option can be used in conjunction with
 .B mktarball

--- a/dkms.8.in
+++ b/dkms.8.in
@@ -318,6 +318,8 @@ combinations on the other kernel.
 .TP
 .B \-\-force
 This option can be used in conjunction with
+.B build, install 
+and 
 .B ldtarball
 to force copying over of extant files.
 .TP


### PR DESCRIPTION
1: The description of the --force option was missing the build and install actions.

2: The --force-version-override option was not documented at all.