### PR TITLE
completion: Add value completion for more arguments

### DIFF
--- a/dkms.bash-completion
+++ b/dkms.bash-completion
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2207
 # bash completion for dkms
 # Copied from the Mandriva dkms package
 
@@ -11,7 +13,7 @@ _kernels()
 # complete on full directory names under $1
 _subdirectories()
 {
-	COMPREPLY=( $( cd $1 && compgen -d -- "$cur" ) )
+	COMPREPLY=( $( cd "$1" && compgen -d -- "$cur" ) )
 }
 
 # complete on $2 part of filenames matching pattern $1 under /usr/src
@@ -37,6 +39,10 @@ _dkms()
 		prev=${COMP_WORDS[COMP_CWORD-1]}
 		command=${COMP_WORDS[1]}
 		case $prev in
+			-a)
+				COMPREPLY=( $( compgen -W "$(uname -m)" -- $cur ) )
+				return 0
+				;;
 			-m)
 				if [ "$command" = 'add' ]; then
 					_filename_parts '.*-.*' 1
@@ -61,15 +67,15 @@ _dkms()
 					return 0
 				fi
 				;;
-			-k)
+			-k|--templatekernel)
 				_kernels
 				return 0
 				;;
-			-@\(c|-spec|-archive|-config\))
+			-c|--spec|--archive|--config)
 				_filedir
 				return 0
 				;;
-			--kernelsourcedir)
+			--kernelsourcedir|--dkmstree|--sourcetree|--installtree)
 				_filedir -d
 				return 0
 				;;


### PR DESCRIPTION
This improves completion by:

- Properly completing directory names and path names for more flags. Basic completion for `-a` was also implemented (defaulting to current architecture)
- Restructure `-@\(c|-spec|-archive|-config\)` to something that works and is simpler. Now, even `extglob` does not need to be enabled for the new completion to work
