### PR TITLE
Report failing command in invoke_command()

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -108,7 +108,11 @@ invoke_command()
     else
         eval "$cmd"; exitval=$?
     fi
-    (($exitval > 0)) && echo -en "(bad exit status: $exitval)"
+    if (($exitval > 0)); then
+        echo -en "(bad exit status: $exitval)"
+        # Print the failing command without the clunky redirection
+        [[ ! $verbose ]] && echo -en "\nFailed command:\n$1"
+    fi
     echo -en "\n"
     return $exitval
 }

--- a/run_test.sh
+++ b/run_test.sh
@@ -1402,6 +1402,8 @@ run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 Building module:
 Cleaning build area...
 Building module(s)...(bad exit status: 2)
+Failed command:
+make -j1 KERNELRELEASE=${KERNEL_VER} all
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} failed for dkms_failing_test(10)
@@ -1419,6 +1421,8 @@ run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 Building module:
 Cleaning build area...
 Building module(s)...(bad exit status: 2)
+Failed command:
+make -j1 KERNELRELEASE=${KERNEL_VER} all
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} failed for dkms_failing_test(10)
@@ -1566,6 +1570,8 @@ This indicates that it should not be built.
 Building module:
 Cleaning build area...
 Building module(s)...(bad exit status: 2)
+Failed command:
+make -j1 KERNELRELEASE=${KERNEL_VER} all
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 


### PR DESCRIPTION
This builds on the ideas in https://github.com/dell/dkms/pull/378, namely:
 - replaces the somewhat misleading/inconsistent "make ..." command during module building
 - passes the redirection file/log as argument to the function
 - prints/reports the failing command
