### PR TITLE
CI: install xz-utils on Debian

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
       if: matrix.distro.name == 'debian'
       run: |
         apt-get update -q
-        apt-get install -qy make linux-headers-amd64 linux-image-amd64 openssl
+        apt-get install -qy make linux-headers-amd64 linux-image-amd64 openssl xz-utils
 
     - name: Install Gentoo Linux dependencies
       if: matrix.distro.name == 'gentoo/stage3'


### PR DESCRIPTION
Recently Debian testing started using xz compressed modules breaking the CI. Upon a look, the xz-utils package and thus xz tool were missing.

/cc @anbe42 