### PR TITLE
get module_compressed_suffix from .config

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -238,9 +238,9 @@ set_module_suffix()
     # $1 = the kernel to base the module_suffix on
     kernel_test="${1:-$(uname -r)}"
     module_uncompressed_suffix=".ko"
-    grep -q '\.gz:' $install_tree/$kernel_test/modules.dep 2>/dev/null && module_compressed_suffix=".gz"
-    grep -q '\.xz:' $install_tree/$kernel_test/modules.dep 2>/dev/null && module_compressed_suffix=".xz"
-    grep -q '\.zst:' $install_tree/$kernel_test/modules.dep 2>/dev/null && module_compressed_suffix=".zst"
+    grep -q '^CONFIG_MODULE_COMPRESS_GZIP=y' $kernel_config 2>/dev/null && module_compressed_suffix=".gz"
+    grep -q '^CONFIG_MODULE_COMPRESS_XZ=y' $kernel_config 2>/dev/null && module_compressed_suffix=".xz"
+    grep -q '^CONFIG_MODULE_COMPRESS_ZSTD=y' $kernel_config 2>/dev/null && module_compressed_suffix=".zst"
     module_suffix="$module_uncompressed_suffix$module_compressed_suffix"
 }
 
@@ -1041,8 +1041,8 @@ prepare_build()
         $"Directory $base_dir already exists. Use the dkms remove function before trying to build again."
 
     # Read the conf file
-    set_module_suffix "$kernelver"
     read_conf_or_die "$kernelver" "$arch"
+    set_module_suffix "$kernelver"
 
     # Error out if build_exclude is set
     [[ $build_exclude ]] && diewarn 77 \
@@ -1788,8 +1788,8 @@ do_status_weak()
 # Spit out all the extra status information that people running DKMS are
 # interested in, but that the DKMS internals do not usually care about.
 module_status_built_extra() (
-    set_module_suffix "$3"
     read_conf "$3" "$4" "$dkms_tree/$1/$2/source/dkms.conf" 2>/dev/null
+    set_module_suffix "$3"
     [[ -d $dkms_tree/$1/original_module/$3/$4 ]] && echo -n " (original_module exists)"
     for ((count=0; count < ${#dest_module_name[@]}; count++)); do
         tree_mod=$(compressed_or_uncompressed "$dkms_tree/$1/$2/$3/$4/module" "${dest_module_name[$count]}")


### PR DESCRIPTION
The old (current) method of parsing `modules.dep` fails to detect compression if none of the currently installed modules are compressed, causing newly built modules to also be uncompressed, even if the kernel supports compression.

Based on 07de9295c42e2ed58c25d8598e17745c5aae3c29, which already added this new behavior to run_test.sh.

Script demonstrating the issue:
```
#!/bin/bash

echo //// Compression settings from /lib/modules/$(uname -r)/build/.config ////
grep -e "CONFIG_MODULE_COMPRESS" /lib/modules/$(uname -r)/build/.config
echo

install_tree=/lib/modules

#### Snippet taken from dkms.in:234 ####
# Figure out the correct module suffix for the kernel we are currently
# dealing with, which may or may not be the currently installed kernel.
set_module_suffix()
{
    # $1 = the kernel to base the module_suffix on
    kernel_test="${1:-$(uname -r)}"
    module_uncompressed_suffix=".ko"
    grep -q '\.gz:' $install_tree/$kernel_test/modules.dep 2>/dev/null && module_compressed_suffix=".gz"
    grep -q '\.xz:' $install_tree/$kernel_test/modules.dep 2>/dev/null && module_compressed_suffix=".xz"
    grep -q '\.zst:' $install_tree/$kernel_test/modules.dep 2>/dev/null && module_compressed_suffix=".zst"
    module_suffix="$module_uncompressed_suffix$module_compressed_suffix"
}

echo //// Full module file extension determined by the current method ////
set_module_suffix $(uname -r)
echo $module_suffix
echo

KERNEL_VER=$(uname -r)

#### Snippet taken from run_test.sh:230 ####
mod_compression_ext=
kernel_config="/lib/modules/${KERNEL_VER}/build/.config"
if [ -f "${kernel_config}" ]; then
    if grep -q "^CONFIG_MODULE_COMPRESS_NONE=y" "${kernel_config}" ; then
        mod_compression_ext=
    elif grep -q "^CONFIG_MODULE_COMPRESS_GZIP=y" "${kernel_config}" ; then
        mod_compression_ext=.gz
    elif grep -q "^CONFIG_MODULE_COMPRESS_XZ=y" "${kernel_config}" ; then
        mod_compression_ext=.xz
    elif grep -q "^CONFIG_MODULE_COMPRESS_ZSTD=y" "${kernel_config}" ; then
        mod_compression_ext=.zst
    fi
fi

module_uncompressed_suffix=".ko"

echo //// Full module file extension expected by the currently failing test ////
echo "$module_uncompressed_suffix$mod_compression_ext"
```

Output on my machine:
```
user@host:~$ ./example.sh
//// Compression settings from /lib/modules/6.5.0-17-generic/build/.config ////
# CONFIG_MODULE_COMPRESS_NONE is not set
# CONFIG_MODULE_COMPRESS_GZIP is not set
# CONFIG_MODULE_COMPRESS_XZ is not set
CONFIG_MODULE_COMPRESS_ZSTD=y

//// Full module file extension determined by the current method ////
.ko

//// Full module file extension expected by the currently failing test ////
.ko.zst
```