### PR TITLE
dkms: use kill -0 $pid instead of /proc/$pid in process exit wait loop

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -95,7 +95,7 @@ invoke_command()
                 wait $(jobs -p) 2>/dev/null
             }
             trap on_exit EXIT
-            while [[ -d /proc/$pid ]]; do
+            while kill -0 $pid > /dev/null 2>&1; do
                 sleep 3 &
                 wait $!
                 echo -en "."


### PR DESCRIPTION
Some Ubuntu installers with custom install commands run DKMS from inside a separate PID namespace without mounting a separate /proc for the new namespace. As a result, this query for /proc/$pid will usually be waiting for an unrelated process in the parent namespace to exit, which sometimes doesn't exist at all or is a process that never exits, causing DKMS to hang forever in these scenarios.

Changing this to kill -0 will ensure that DKMS always checks for the PID in the correct namespace regardless of which /proc is mounted. We are also investigating solutions that can be implemented on our end for this issue, but since this issue causes undefined behavior on *any* system with a separate PID namespace and shared /proc, we feel this patch is appropriate for DKMS to ensure robustness in other implementations similar to ours.

Link to Ubuntu bug report: https://bugs.launchpad.net/curtin/+bug/2037682