### PR TITLE
CI: temporary drop the Ubuntu 22.04 VM

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,7 +149,10 @@ jobs:
     strategy:
       matrix:
         version:
-          - 22.04
+        # The Canonical team has chosen to disable module compression by
+        # patching the kernel Makefile.modinst. For more context see:
+        # https://github.com/dell/dkms/issues/405
+        # - 22.04
           - 20.04
     runs-on: ubuntu-${{ matrix.version }}
 


### PR DESCRIPTION
As the inline comment says - instead of flipping the CONFIG toggle, the team has decided to patch the kernel build system :thinking:

This results in borked tests, since dkms code still (incorrectly) parses the modules.dep to determine the compression type, while the tests do not.