### PR TITLE
dkms: fix building nvidia open kernel modules against clang and thin/full lto compiled kernel

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -625,17 +625,11 @@ read_conf()
     # Check if clang was used to compile or lld was used to link the kernel.
     if [[ -e $kernel_source_dir/vmlinux ]]; then
       if  readelf -p .comment $kernel_source_dir/vmlinux | grep -q clang; then
-        make_command="${make_command} CC=clang"
-      fi
-      if  readelf -p .comment $kernel_source_dir/vmlinux | grep -q LLD; then
-        make_command="${make_command} LD=ld.lld"
+        make_command="${make_command} LLVM=1"
       fi
     elif [[ -e "${kernel_config}" ]]; then
       if grep -q CONFIG_CC_IS_CLANG=y "${kernel_config}"; then
-        make_command="${make_command} CC=clang"
-      fi
-      if grep -q CONFIG_LD_IS_LLD=y "${kernel_config}"; then
-        make_command="${make_command} LD=ld.lld"
+        make_command="${make_command} LLVM=1"
       fi
     fi
 
@@ -1150,7 +1144,11 @@ actual_build()
         local built_module="$the_module$module_uncompressed_suffix"
         local compressed_module="$the_module$module_suffix"
 
-        [[ ${strip[$count]} != no ]] && strip -g "$built_module"
+        if [[ ${strip[$count]} != no ]] && [[ ${CC} == "clang" ]]; then
+            llvm-strip -g "$built_module"
+        elif [[ ${strip[$count]} != no ]]; then
+            strip -g "$built_module"
+        fi
 
         if (( do_signing )); then
             echo "Signing module $built_module"


### PR DESCRIPTION
Right now there's some issues when trying to compile open-gpu-kernel-modules against a kernel compiled using Clang and Thin/Full LTO.

Also the script will pick the wrong version of the `strip` command otherwise the module will fail to compile successfully:
```
strip: BFD (GNU Binutils) 2.42.0 assertion fail /usr/src/debug/binutils/binutils-gdb/bfd/elf.c:4131
strip: BFD (GNU Binutils) 2.42.0 assertion fail /usr/src/debug/binutils/binutils-gdb/bfd/elf.c:4131
strip: BFD (GNU Binutils) 2.42.0 assertion fail /usr/src/debug/binutils/binutils-gdb/bfd/elf.c:4131
...
```
Is also necessary to set the `OBJCOPY` environment variable, otherwise even though the modules will compile the system will refuse to boot on it.

Fixes #416.