### PR TITLE
CI: drop CentOS Stream 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           - {name: "archlinux", tag: "latest", variant: "-lts"}
           - {name: "archlinux", tag: "latest", variant: "-zen"}
           - {name: "centos/centos", tag: "stream9", url: "quay.io/"}
-          - {name: "centos/centos", tag: "stream8", url: "quay.io/"}
           - {name: "centos", tag: "7"}
           - {name: "debian", tag: "testing"}
           - {name: "debian", tag: "12"}


### PR DESCRIPTION
It has gone EOL a few days ago and the job is failing. CentOS 7 will go down soon, but we'll keep the CI while it's still working.

It anyone wants to add Rocky Linux into the mix, or any other, PRs are open :-D

@scaronni you mentioned CentOS in https://github.com/dell/dkms/pull/349 - is that 7 only, or does it include Stream 8?