### PR TITLE
Update CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
           - {name: "gentoo/stage3", tag: "latest"}
           - {name: "opensuse/tumbleweed", tag: "latest", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "opensuse/leap", tag: "15.5", variant: "-default", url: "registry.opensuse.org/"}
+          - {name: "ubuntu", tag: "24.04"}
           - {name: "ubuntu", tag: "23.10"}
           - {name: "ubuntu", tag: "22.04"}
           - {name: "ubuntu", tag: "20.04"}


### PR DESCRIPTION
Drop a few distros that have gone EOL (Fedora 38 and Alpine 3.16) adding the new versions respectively.

In a month or two, Debian 10, CentOS 7 and Ubuntu 23.10 will go EOL. At that point we could consider also dropping Ubuntu 18.04 to unblock https://github.com/dell/dkms/pull/349.