### PR TITLE
Tests fixes for clang

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -195,6 +195,9 @@ generalize_expected_output() {
     # Apport related error that can occur in the CI. Drop from the output to be more generic
     sed -i "/^python3: can't open file '\/usr\/share\/apport\/package-hooks\/dkms_packages.py'\: \[Errno 2\] No such file or directory$/d" ${output_log}
     sed -i "/^ERROR (dkms apport): /d" ${output_log}
+
+    # Swap any CC/LD/... flags (if set) with a placeholder message
+    sed -i "s|\(make -j1 KERNELRELEASE=${KERNEL_VER} all\).*|\1 <omitting possibly set CC/LD/... flags>|" ${output_log}
 }
 
 run_with_expected_output() {
@@ -1425,7 +1428,7 @@ Building module:
 Cleaning build area...
 Building module(s)...(bad exit status: 2)
 Failed command:
-make -j1 KERNELRELEASE=${KERNEL_VER} all
+make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} failed for dkms_failing_test(10)
@@ -1444,7 +1447,7 @@ Building module:
 Cleaning build area...
 Building module(s)...(bad exit status: 2)
 Failed command:
-make -j1 KERNELRELEASE=${KERNEL_VER} all
+make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} failed for dkms_failing_test(10)
@@ -1593,7 +1596,7 @@ Building module:
 Cleaning build area...
 Building module(s)...(bad exit status: 2)
 Failed command:
-make -j1 KERNELRELEASE=${KERNEL_VER} all
+make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 


### PR DESCRIPTION
Should address the issues raised in https://github.com/dell/dkms/pull/417#issuecomment-2148525439

Namely:
 - modinfo output can vary - I suspect it prints the entries the way they're stored/parsed off the module
 - on (expected) failing tests, we don't print the CC/LD/OBJDUMP flags - just use a place holder

@ltsdw can you please test this PR on your end? I wrote it blindly, so I'm not 100% sure it addresses all the issues.