### PR TITLE
Allow running MOK generation as a command

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -244,6 +244,13 @@ action may be used to re-add the module/version combination to dkms.
 .IP "" 4
 Attempt to install the latest revision of all modules that have been installed for other kernel revisions.
 dkms_autoinstaller is a stub that uses this action to perform its work.
+.SY generate_mok
+.YS
+.IP "" 4
+Command to be issued standalone to generate Secure Boot keys. Required only if prior manipulation of the keys is needed,
+otherwise the keys are automatically generated on the first build attempt of a DKMS module.
+
+No additional arguments are parsed.
 .SH OPTIONS
 .TP
 .B \-m <module>/<module\-version>

--- a/dkms.bash-completion.in
+++ b/dkms.bash-completion.in
@@ -30,7 +30,7 @@ _dkms()
 
 	if [[ $COMP_CWORD -eq 1 ]] ; then
 		COMPREPLY=( $( compgen -W "add remove build unbuild install uninstall autoinstall \
-			match mktarball ldtarball \
+			match mktarball ldtarball generate_mok \
 			status" -- $cur ) )
 	else
 		prev=${COMP_WORDS[COMP_CWORD-1]}
@@ -113,7 +113,10 @@ _dkms()
 					;;
 				status)
 					options=''
-				;;
+				    ;;
+				generate_mok)
+					options=''
+				    ;;
 			esac
 
 			options="$options -m -v -k -a --arch -q --quiet -V \

--- a/dkms.in
+++ b/dkms.in
@@ -166,7 +166,7 @@ show_usage()
 {
     echo $"Usage: $0 [action] [options]"
     echo $"  [action]  = { add | remove | build | unbuild | install | uninstall | match |"
-    echo $"               autoinstall | mktarball | ldtarball | status }"
+    echo $"               autoinstall | mktarball | ldtarball | status | generate_mok }"
     echo $"  [options] = [-m module] [-v module-version] [-k kernel-version] [-a arch]"
     echo $"              [-c dkms.conf-location] [-q] [--force] [--force-version-override] [--all]"
     echo $"              [--templatekernel=kernel] [--directive='cli-directive=cli-value']"
@@ -923,48 +923,8 @@ prepare_kernel()
     }
 }
 
-prepare_signing()
+prepare_mok()
 {
-    do_signing=0
-
-    if [[ ! -f ${kernel_config} ]]; then
-        echo "Kernel config ${kernel_config} not found, modules won't be signed"
-        return
-    fi
-
-    if ! grep -q "^CONFIG_MODULE_SIG_HASH=" "${kernel_config}"; then
-        echo "The kernel is built without module signing facility, modules won't be signed"
-        return
-    fi
-
-    sign_hash=$(grep "^CONFIG_MODULE_SIG_HASH=" "${kernel_config}" | cut -f2 -d= | sed 's/"//g')
-
-    # Lazy source in signing related configuration
-    read_framework_conf $dkms_framework_signing_variables
-
-    if [[ ! ${sign_file} ]]; then
-        case "$running_distribution" in
-            debian* )
-                sign_file="/usr/lib/linux-kbuild-${kernelver%.*}/scripts/sign-file"
-                ;;
-            ubuntu* )
-                sign_file="$(command -v kmodsign)"
-                if [[ ! -x "${sign_file}" ]]; then
-                    sign_file="/usr/src/linux-headers-$kernelver/scripts/sign-file"
-                fi
-                ;;
-        esac
-        if [[ ! -f ${sign_file} ]]; then
-            sign_file="$install_tree/$kernelver/build/scripts/sign-file"
-        fi
-    fi
-    echo "Sign command: $sign_file"
-
-    if [[ ! -f ${sign_file} || ! -x ${sign_file} ]]; then
-        echo "Binary ${sign_file} not found, modules won't be signed"
-        return
-    fi
-
     if [[ -z "${mok_signing_key}" ]]; then
         # No custom key specified, use the default key created by update-secureboot-policy for Ubuntu
         # Debian's update-secureboot-policy has no --new-key option
@@ -1021,6 +981,48 @@ prepare_signing()
         echo "Certificate file ${mok_certificate} not found and can't be generated, modules won't be signed"
         return
     fi
+}
+
+prepare_signing()
+{
+    do_signing=0
+
+    if [[ ! -f ${kernel_config} ]]; then
+        echo "Kernel config ${kernel_config} not found, modules won't be signed"
+        return
+    fi
+
+    if ! grep -q "^CONFIG_MODULE_SIG_HASH=" "${kernel_config}"; then
+        echo "The kernel is built without module signing facility, modules won't be signed"
+        return
+    fi
+
+    sign_hash=$(grep "^CONFIG_MODULE_SIG_HASH=" "${kernel_config}" | cut -f2 -d= | sed 's/"//g')
+
+    if [[ ! ${sign_file} ]]; then
+        case "$running_distribution" in
+            debian* )
+                sign_file="/usr/lib/linux-kbuild-${kernelver%.*}/scripts/sign-file"
+                ;;
+            ubuntu* )
+                sign_file="$(command -v kmodsign)"
+                if [[ ! -x "${sign_file}" ]]; then
+                    sign_file="/usr/src/linux-headers-$kernelver/scripts/sign-file"
+                fi
+                ;;
+        esac
+        if [[ ! -f ${sign_file} ]]; then
+            sign_file="$install_tree/$kernelver/build/scripts/sign-file"
+        fi
+    fi
+    echo "Sign command: $sign_file"
+
+    if [[ ! -f ${sign_file} || ! -x ${sign_file} ]]; then
+        echo "Binary ${sign_file} not found, modules won't be signed"
+        return
+    fi
+
+    prepare_mok
 
     do_signing=1
 }
@@ -1191,6 +1193,8 @@ do_build()
 {
     set_kernel_source_dir_and_kconfig "$kernelver"
     prepare_kernel "$kernelver" "$arch"
+    # Lazy source in signing related configuration
+    read_framework_conf $dkms_framework_signing_variables
     prepare_signing
     prepare_build
     actual_build
@@ -2452,7 +2456,7 @@ die_is_fatal="yes"
 [ -x /usr/lib/module-init-tools/weak-modules ] && weak_modules='/usr/lib/module-init-tools/weak-modules'
 no_depmod=""
 
-action_re='^(remove|(auto|un)?install|match|mktarball|(un)?build|add|status|ldtarball)$'
+action_re='^(remove|(auto|un)?install|match|mktarball|(un)?build|add|status|ldtarball|generate_mok)$'
 
 # Parse command line arguments
 while (($# > 0)); do
@@ -2662,6 +2666,10 @@ ldtarball) # Make sure they're root if we're using --force
         die 1 $"You must be root to use this command with the --force option."
     fi
     load_tarball && add_module
+    ;;
+generate_mok)
+    read_framework_conf $dkms_framework_signing_variables
+    prepare_mok
     ;;
 *)
     error $"Unknown action specified: \"$action\""

--- a/dkms.zsh-completion.in
+++ b/dkms.zsh-completion.in
@@ -17,6 +17,7 @@ subcmds=(
   'mktarball:tar up files in the DKMS tree for a specific module'
   'ldtarball:extract a tarball created with mktarball into the DKMS tree'
   'status:display the current status of modules, versions and kernels within the tree'
+  'generate_mok:generate the MOK keys outside of the first build'
 )
 
 args=(
@@ -110,6 +111,9 @@ case $cmd in
     args+=(
       '3:rpm file:_files -g "*.rpm(-.)"'
     )
+  ;;
+  generate_mok)
+    args=()
   ;;
 esac
 


### PR DESCRIPTION
Allow calling part of `prepare_signing` as a standalone function to generate the MOK key as a standalone command.

This is for the use case described here: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/2034#note_2147952

```
$ sudo dkms generate_mok
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub
```
This is the minimal change to get the command available. Open to suggestions if we should instead rework the whole signing logic.

