### PR TITLE
Reduce output when installing/uninstalling

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1118,7 +1118,6 @@ actual_build()
     local -r build_log="$build_dir/make.log"
 
     echo $""
-    echo $"Building module:"
 
     invoke_command "$clean" "Cleaning build area" '' background
     echo $"DKMS make.log for $module-$module_version for kernel $kernelver ($arch)" >> "$build_log"

--- a/dkms.in
+++ b/dkms.in
@@ -120,6 +120,7 @@ invoke_command()
 
 error() (
     exec >&2
+    echo $""
     echo -n $"Error! "
     for s in "$@"; do echo "$s"; done
 )
@@ -740,7 +741,6 @@ check_version_sanity()
     # $4 = dest_module_name
 
     local lib_tree="$install_tree/$1" res=
-    echo $"Running module version sanity check."
     local i=0
     if [[ -n $3 ]]; then
         # Magic split into array syntax saves trivial awk and cut calls.
@@ -785,8 +785,7 @@ check_version_sanity()
     fi
 
     if [[ ${kernels_module[1]} ]]; then
-        warn $"Warning! Cannot do version sanity checking because multiple ${4}$module_suffix" \
-            $"modules were found in kernel $1."
+        warn $"Warning! Cannot do version sanity checking because multiple ${4}$module_suffix modules were found in kernel $1."
         return 0
     fi
     local dkms_module=$(compressed_or_uncompressed "$dkms_tree/$module/$module_version/$1/$2/module/" "${4}")
@@ -804,10 +803,7 @@ check_version_sanity()
             # if the module has neither version nor srcversion/checksum, check the binary files instead
             local verinfo="$(get_module_verinfo "${dkms_module}")"
             if [[ "$(echo "$verinfo" | tr -d '[:space:]')" ]] || diff "${kernels_module}" "${dkms_module}" &>/dev/null; then
-                echo $"Module version $(echo "$verinfo" | head -n 1) for $4${module_suffix}" >&2
-                echo $"exactly matches what is already found in kernel $1." >&2
-                echo $"DKMS will not replace this module." >&2
-                echo $"You may override by specifying --force." >&2
+                echo $"Module ${kernels_module} already installed at version $(echo "$verinfo" | head -n 1), override by specifying --force" >&2
                 return 1
             fi
         fi
@@ -1156,7 +1152,7 @@ actual_build()
 
         if (( do_signing )); then
             echo "Signing module $built_module"
-            "$sign_file" "$sign_hash" "$mok_signing_key" "$mok_certificate" "$built_module"
+            "$sign_file" "$sign_hash" "$mok_signing_key" "$mok_certificate" "$built_module" 2>/dev/null
         fi
 
         if [[ $module_compressed_suffix = .gz ]]; then
@@ -1270,9 +1266,9 @@ do_install()
     local lib_tree="$install_tree/$kernelver"
     local any_module_installed
     local count
+
+    echo $""
     for ((count=0; count < ${#built_module_name[@]}; count++)); do
-        echo $""
-        echo $"${dest_module_name[$count]}$module_suffix:"
         # Check this version against what is already in the kernel
         check_version_sanity "$kernelver" "$arch" "$obsolete_by" "${dest_module_name[$count]}" || continue
 
@@ -1283,11 +1279,10 @@ do_install()
         local m=${dest_module_name[$count]}
         local installed_modules=$(find_module "$lib_tree" "$m")
         local module_count=${#installed_modules[@]}
-        echo $" - Original module"
         local original_copy=$(compressed_or_uncompressed "$dkms_tree/$module/original_module/$kernelver/$arch" "$m")
         if [[ -L $dkms_tree/$module/kernel-$kernelver-$arch &&
             -n "$original_copy" ]]; then
-            echo $"   - An original module was already stored during a previous install"
+            echo $"An original module was already stored during a previous install"
         elif ! [[ -L $dkms_tree/$module/kernel-$kernelver-$arch ]]; then
             local archive_pref1=$(compressed_or_uncompressed "$lib_tree/extra" "$m")
             local archive_pref2=$(compressed_or_uncompressed "$lib_tree/updates" "$m")
@@ -1298,60 +1293,31 @@ do_install()
             local found_orginal=""
             for original_module in $archive_pref1 $archive_pref2 $archive_pref3 $archive_pref4; do
                 [[ -f $original_module ]] || continue
-                case "$running_distribution" in
-                    debian* | ubuntu* )
-                        ;;
-                    *)
-                        echo $"   - Found $original_module"
-                        echo $"   - Storing in $dkms_tree/$module/original_module/$kernelver/$arch/"
-                        echo $"   - Archiving for uninstallation purposes"
-                        mkdir -p "$dkms_tree/$module/original_module/$kernelver/$arch"
-                        mv -f "$original_module" "$dkms_tree/$module/original_module/$kernelver/$arch/"
-                        ;;
-                esac
+                echo $"Found pre-existing $original_module, archiving for uninstallation"
+                mkdir -p "$dkms_tree/$module/original_module/$kernelver/$arch"
+                mv -f "$original_module" "$dkms_tree/$module/original_module/$kernelver/$arch/"
                 found_original="yes"
                 break
             done
             if [[ ! $found_original ]] && ((module_count > 1)); then
-                echo $"   - Multiple original modules exist but DKMS does not know which to pick"
-                echo $"   - Due to the confusion, none will be considered during a later uninstall"
-            elif [[ ! $found_original ]]; then
-                echo $"   - No original module exists within this kernel"
+                echo $"Multiple original modules exist, so none will be put back in place during a later uninstall"
+                echo $"All instances will be stored for reference purposes in $dkms_tree/$module/original_module/$kernelver/$arch/collisions/"
             fi
-        else
-            echo $"   - This kernel never originally had a module by this name"
         fi
 
         if ((module_count > 1)); then
-            echo $" - Multiple same named modules!"
-            echo $"   - $module_count named $m$module_suffix in $lib_tree/"
-            case "$running_distribution" in
-                debian* | ubuntu* )
-                    ;;
-                *)
-                    echo $"   - All instances of this module will now be stored for reference purposes ONLY"
-                    echo $"   - Storing in $dkms_tree/$module/original_module/$kernelver/$arch/collisions/"
-                    ;;
-            esac
+            echo $"Multiple same named modules! $module_count named $m$module_suffix in $lib_tree/"
             for module_dup in $(find_module "$lib_tree" "$m"); do
                 dup_tree="${module_dup#$lib_tree}";
                 dup_name="${module_dup##*/}"
                 dup_tree="${dup_tree/${dup_name}}"
-                case "$running_distribution" in
-                    debian* | ubuntu* )
-                        ;;
-                    *)
-                       echo $"     - Stored $module_dup"
-                       mkdir -p "$dkms_tree/$module/original_module/$kernelver/$arch/collisions/$dup_tree"
-                       mv -f $module_dup "$dkms_tree/$module/original_module/$kernelver/$arch/collisions/$dup_tree"
-                       ;;
-                esac
+                mkdir -p "$dkms_tree/$module/original_module/$kernelver/$arch/collisions/$dup_tree"
+                mv -f $module_dup "$dkms_tree/$module/original_module/$kernelver/$arch/collisions/$dup_tree"
             done
         fi
 
         # Copy module to its location
-        echo $" - Installation"
-        echo $"   - Installing to $install_tree/$kernelver${dest_module_location[$count]}/"
+        echo $"Installing $install_tree/$kernelver${dest_module_location[$count]}/${dest_module_name[$count]}$module_suffix"
         mkdir -p $install_tree/$kernelver${dest_module_location[$count]}
         [[ $symlink_modules ]] && symlink="-s"
         local toinstall=$(compressed_or_uncompressed "$base_dir/module" "$m")
@@ -1359,6 +1325,8 @@ do_install()
         any_module_installed=1
 
     done
+
+    echo $""
 
     if ((${#built_module_name[@]} > 0)) && [[ ! "${any_module_installed}" ]]; then
         die 6 $"Installation aborted."
@@ -1379,7 +1347,7 @@ do_install()
     # Run the post_install script
     run_build_script post_install "$post_install"
 
-    invoke_command "do_depmod $kernelver" "depmod" '' background || {
+    invoke_command "do_depmod $kernelver" "Running depmod" '' background || {
         do_uninstall "$kernelver" "$arch"
         die 6 $"Problems with depmod detected. Automatically uninstalling this module." \
             $"Install Failed (depmod problems). Module rolled back to built state."
@@ -1571,13 +1539,12 @@ do_uninstall()
             fi
         fi
 
+        echo $""
         for ((count=0; count < ${#built_module_name[@]}; count++)); do
             real_dest_module_location="$(find_actual_dest_module_location $module $count $1 $2)"
-            echo $""
-            echo $"${dest_module_name[$count]}$module_suffix:"
-            echo $" - Uninstallation"
+
             if [[ ${real_dest_module_location} ]]; then
-                echo $"   - Deleting from: $install_tree/$1${real_dest_module_location}/"
+                echo $"Deleting $install_tree/$1${real_dest_module_location}/${dest_module_name[$count]}$module_suffix"
                 rm -f "$install_tree/$1${real_dest_module_location}/${dest_module_name[$count]}$module_uncompressed_suffix"*
                 dir_to_remove="${real_dest_module_location#/}"
                 while [[ ${dir_to_remove} != ${dir_to_remove#/} ]]; do
@@ -1585,27 +1552,18 @@ do_uninstall()
                 done
                 (if cd "$install_tree/$1"; then rpm -qf "${dir_to_remove}" >/dev/null 2>&1 || rmdir -p --ignore-fail-on-non-empty "${dir_to_remove}"; fi || true)
             else
-                echo $"   - Module was not found within $install_tree/$1/"
+                echo $"Module was not found within $install_tree/$1/"
             fi
-            echo $" - Original module"
             local origmod=$(compressed_or_uncompressed "$dkms_tree/$module/original_module/$1/$2" "${dest_module_name[$count]}")
             if [[ -n $origmod ]]; then
-                case "$running_distribution" in
-                    debian* | ubuntu* )
-                        ;;
-                    *)
-                        echo $"   - Archived original module found in the DKMS tree"
-                        echo $"   - Moving it to: $install_tree/$1${DEST_MODULE_LOCATION[$count]}/"
-                        mkdir -p "$install_tree/$1${DEST_MODULE_LOCATION[$count]}/"
-                        mv -f "$origmod" "$install_tree/$1${DEST_MODULE_LOCATION[$count]}/" 2>/dev/null
-                        ;;
-                esac
-            else
-                echo $"   - No original module was found for this module on this kernel."
-                echo $"   - Use the dkms install command to reinstall any previous module version."
+                echo $"Restoring archived original module"
+                mkdir -p "$install_tree/$1${DEST_MODULE_LOCATION[$count]}/"
+                mv -f "$origmod" "$install_tree/$1${DEST_MODULE_LOCATION[$count]}/" 2>/dev/null
             fi
         done
         rm -f "$dkms_tree/$module/kernel-$1-$2"
+
+        echo $""
     else
         echo $"This module version was INACTIVE for this kernel."
     fi
@@ -1614,7 +1572,7 @@ do_uninstall()
     run_build_script post_remove "$post_remove"
 
     # Run depmod because we changed $install_tree
-    invoke_command "do_depmod $1" "depmod" '' background
+    invoke_command "do_depmod $1" "Running depmod" '' background
 
     # Delete the original_module if nothing for this kernel is installed anymore
     if [[ $was_active && -d $dkms_tree/$module/original_module/$1/$2 && ! -d $dkms_tree/$module/original_module/$1/$2/collisions ]]; then

--- a/dkms.in
+++ b/dkms.in
@@ -112,8 +112,9 @@ invoke_command()
         echo -en "(bad exit status: $exitval)"
         # Print the failing command without the clunky redirection
         [[ ! $verbose ]] && echo -en "\nFailed command:\n$1"
+    else
+        echo " done."
     fi
-    echo -en "\n"
     return $exitval
 }
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -168,10 +168,6 @@ generalize_expected_output() {
     # On CentOS, weak-modules is executed. Drop it from the output, to be more generic
     sed -i '/^Adding any weak-modules$/d' ${output_log}
     sed -i '/^Removing any linked weak-modules$/d' ${output_log}
-    # "depmod..." lines are missing when uninstalling modules on CentOS. Remove them to be more generic
-    if [[ $# -ge 2 && "$2" =~ uninstall|unbuild|remove ]] ; then
-        sed -i '/^depmod\.\.\.$/d' ${output_log}
-    fi
     # Signing related output. Drop it from the output, to be more generic
     if (( NO_SIGNING_TOOL == 0 )); then
         sed -i '/^EFI variables are not supported on this system/d' ${output_log}
@@ -300,6 +296,7 @@ rm /etc/dkms/framework.conf.d/dkms_test_framework.conf
 
 echo 'Adding the test module by version (expected error)'
 run_with_expected_error 2 dkms add -m dkms_test -v 1.0 << EOF
+
 Error! Could not find module source directory.
 Directory: /usr/src/dkms_test-1.0 does not exist.
 EOF
@@ -318,12 +315,14 @@ fi
 
 echo 'Adding the test module again (expected error)'
 run_with_expected_error 3 dkms add test/dkms_test-1.0 << EOF
+
 Error! DKMS tree already contains: dkms_test-1.0
 You cannot add the same module/version combo more than once.
 EOF
 
 echo 'Adding the test module by version (expected error)'
 run_with_expected_error 3 dkms add -m dkms_test -v 1.0 << EOF
+
 Error! DKMS tree already contains: dkms_test-1.0
 You cannot add the same module/version combo more than once.
 EOF
@@ -332,10 +331,9 @@ echo 'Building the test module'
 set_signing_message "dkms_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -355,55 +353,51 @@ if (( NO_SIGNING_TOOL == 0 )); then
     run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
 Binary /no/such/file not found, modules won't be signed
 
-Building module:
-Cleaning build area...
-Building module(s)...
-Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+Cleaning build area... done.
 EOF
 
-    echo 'Building the test module with bad mok_signing_key path in framework file'
+    echo ' Building the test module with bad mok_signing_key path in framework file'
     cp test/framework/bad_key_file_path.conf /etc/dkms/framework.conf.d/dkms_test_framework.conf
     run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
 Key file /no/such/path.key not found and can't be generated, modules won't be signed
 
-Building module:
-Cleaning build area...
-Building module(s)...
-Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 
-    echo 'Building the test module with bad mok_certificate path in framework file'
+    echo ' Building the test module with bad mok_certificate path in framework file'
     cp test/framework/bad_cert_file_path.conf /etc/dkms/framework.conf.d/dkms_test_framework.conf
     run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
 Certificate file /no/such/path.crt not found and can't be generated, modules won't be signed
 
-Building module:
-Cleaning build area...
-Building module(s)...
-Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
     rm /tmp/dkms_test_private_key
 
-    echo 'Building the test module with path contains variables in framework file'
+    echo ' Building the test module with path contains variables in framework file'
     mkdir "/tmp/dkms_test_dir_${KERNEL_VER}/"
     cp test/framework/variables_in_path.conf /etc/dkms/framework.conf.d/dkms_test_framework.conf
     run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
     rm -r "/tmp/dkms_test_dir_${KERNEL_VER}/"
 
     BUILT_MODULE_PATH="/var/lib/dkms/dkms_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/module/dkms_test.ko${mod_compression_ext}"
     CURRENT_HASH="$(modinfo -F sig_hashalgo "${BUILT_MODULE_PATH}")"
 
-    echo 'Building the test module using a different hash algorithm'
+    echo ' Building the test module using a different hash algorithm'
     if kmod_broken_hashalgo; then
-        echo 'Current kmod has broken hash algorithm code. Skipping...'
+        echo '  Current kmod has broken hash algorithm code. Skipping...'
     elif [[ "${CURRENT_HASH}" == "unknown" ]]; then
-        echo 'Current kmod reports unknown hash algorithm. Skipping...'
+        echo '  Current kmod reports unknown hash algorithm. Skipping...'
     else
         cp test/framework/temp_key_cert.conf /etc/dkms/framework.conf.d/dkms_test_framework.conf
 
@@ -415,10 +409,9 @@ EOF
         echo "CONFIG_MODULE_SIG_HASH=\"${ALTER_HASH}\"" > /tmp/dkms_test_kconfig
         run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --config /tmp/dkms_test_kconfig --force << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
         run_with_expected_output sh -c "modinfo -F sig_hashalgo '${BUILT_MODULE_PATH}'" << EOF
 ${ALTER_HASH}
@@ -434,30 +427,25 @@ cp test/framework/temp_key_cert.conf /etc/dkms/framework.conf.d/dkms_test_framew
 echo 'Building the test module again by force'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
 EOF
 
 if (( NO_SIGNING_TOOL == 0 )); then
-    echo 'Extracting serial number from the certificate'
+    echo ' Extracting serial number from the certificate'
     MODULE_SERIAL="$(cert_serial /tmp/dkms_test_certificate)"
 fi
 
 echo 'Installing the test module'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 
-dkms_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
@@ -480,21 +468,13 @@ run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 --f
 Module dkms_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
-depmod...
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 
-dkms_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Running depmod... done.
+
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
@@ -509,14 +489,14 @@ version:        1.0
 EOF
 
 if (( NO_SIGNING_TOOL == 0 )); then
-    echo 'Checking module signature'
+    echo ' Checking module signature'
     SIG_KEY="$(modinfo -F sig_key "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}" | tr -d ':')"
     SIG_HASH="$(modinfo -F sig_hashalgo "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}")"
 
     if kmod_broken_hashalgo; then
-        echo 'Current kmod has broken hash algorithm code. Skipping...'
+        echo '  Current kmod has broken hash algorithm code. Skipping...'
     elif [[ "${SIG_HASH}" == "unknown" ]]; then
-        echo 'Current kmod reports unknown hash algorithm. Skipping...'
+        echo '  Current kmod reports unknown hash algorithm. Skipping...'
     elif [[ ! "${SIG_KEY}" ]]; then
         echo >&2 "Error: module was not signed"
         exit 1
@@ -532,12 +512,9 @@ run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_test -v 1.0 <
 Module dkms_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -604,18 +581,13 @@ echo 'Installing the test module by version (combining add, build, install)'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 
-dkms_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
@@ -634,14 +606,14 @@ version:        1.0
 EOF
 
 if (( NO_SIGNING_TOOL == 0 )); then
-    echo 'Checking module signature'
+    echo ' Checking module signature'
     SIG_KEY="$(modinfo -F sig_key "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}" | tr -d ':')"
     SIG_HASH="$(modinfo -F sig_hashalgo "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}")"
 
     if kmod_broken_hashalgo; then
-        echo 'Current kmod has broken hash algorithm code. Skipping...'
+        echo '  Current kmod has broken hash algorithm code. Skipping...'
     elif [[ "${SIG_HASH}" == "unknown" ]]; then
-        echo 'Current kmod reports unknown hash algorithm. Skipping...'
+        echo '  Current kmod reports unknown hash algorithm. Skipping...'
     elif [[ ! "${SIG_KEY}" ]]; then
         # kmod may not be linked with openssl and thus can't extract the key from module
         echo >&2 "Error: modules was not signed, or key is unknown"
@@ -658,12 +630,9 @@ run_with_expected_output dkms remove --all -m dkms_test -v 1.0 << EOF
 Module dkms_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 Deleting module dkms_test-1.0 completely from the DKMS tree.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -680,10 +649,9 @@ echo 'Building the test module by config file (combining add, build)'
 run_with_expected_output dkms build -k "${KERNEL_VER}" test/dkms_test-1.0/dkms.conf << EOF
 Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -692,13 +660,9 @@ EOF
 echo "Running dkms autoinstall"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 
-dkms_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} succeeded for dkms_test
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -707,9 +671,11 @@ EOF
 
 echo "Running dkms autoinstall for a kernel without headers installed (expected error)"
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}-noheaders" << EOF
+
 Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
 Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
 dkms autoinstall on ${KERNEL_VER}-noheaders/${KERNEL_ARCH} failed for dkms_test(1)
+
 Error! One or more modules failed to install during autoinstall.
 Refer to previous errors for more information.
 EOF
@@ -719,12 +685,9 @@ run_with_expected_output dkms remove --all -m dkms_test -v 1.0 << EOF
 Module dkms_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 Deleting module dkms_test-1.0 completely from the DKMS tree.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -769,10 +732,9 @@ echo 'Building the noautoinstall test module'
 set_signing_message "dkms_noautoinstall_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_noautoinstall_test -v 1.0 << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
 dkms_noautoinstall_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -781,13 +743,9 @@ EOF
 echo 'Installing the noautoinstall test module'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_noautoinstall_test -v 1.0 << EOF
 
-dkms_noautoinstall_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noautoinstall_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
 dkms_noautoinstall_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
@@ -798,12 +756,9 @@ run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_noautoinstall
 Module dkms_noautoinstall_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_noautoinstall_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noautoinstall_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
 dkms_noautoinstall_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -848,6 +803,7 @@ abspwd=$(readlink -f $(pwd))
 
 echo 'Testing dkms add of source tree without dkms.conf (expected error)'
 run_with_expected_error 1 dkms add ${abspwd}/test/dkms_conf_test_no_conf << EOF
+
 Error! Arguments <module> and <module-version> are not specified.
 Usage: add <module>/<module-version> or
        add -m <module>/<module-version> or
@@ -859,6 +815,7 @@ run_with_expected_error 8 dkms add test/dkms_conf_test_empty << EOF
 dkms.conf: Error! No 'PACKAGE_NAME' directive specified.
 dkms.conf: Error! No 'PACKAGE_VERSION' directive specified.
 dkms.conf: Warning! Zero modules specified.
+
 Error! Bad conf file.
 File: ${abspwd}/test/dkms_conf_test_empty/dkms.conf does not represent a valid dkms.conf file.
 EOF
@@ -873,6 +830,7 @@ dkms.conf: Error! 'BUILT_MODULE_NAME' directive ends in '.o' or '.ko' in record 
 dkms.conf: Error! No 'DEST_MODULE_LOCATION' directive specified for record #1.
 dkms.conf: Error! Directive 'DEST_MODULE_LOCATION' does not begin with
 '/kernel', '/updates', or '/extra' in record #1.
+
 Error! Bad conf file.
 File: ${abspwd}/test/dkms_conf_test_invalid/dkms.conf does not represent a valid dkms.conf file.
 EOF
@@ -898,11 +856,12 @@ run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_conf_test -v 1.
 dkms.conf: Warning! Zero modules specified.
 Creating symlink /var/lib/dkms/dkms_conf_test/1.0/source -> /usr/src/dkms_conf_test-1.0
 
-Building module:
-Cleaning build area...
-Building module(s)...
-Cleaning build area...
-depmod...
+Cleaning build area... done.
+Building module(s)... done.
+Cleaning build area... done.
+
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_conf_test' << EOF
 dkms.conf: Warning! Zero modules specified.
@@ -914,6 +873,9 @@ dkms.conf: Warning! Zero modules specified.
 dkms.conf: Warning! Zero modules specified.
 Module dkms_conf_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
+
+
+Running depmod... done.
 Deleting module dkms_conf_test-1.0 completely from the DKMS tree.
 EOF
 
@@ -927,6 +889,7 @@ EOF
 
 echo 'Building test module without source (expected error)'
 run_with_expected_error 8 dkms build -k "${KERNEL_VER}" -m dkms_conf_test -v 1.0 << EOF
+
 Error! The directory /var/lib/dkms/dkms_conf_test/1.0/source does not appear to have module source located within it.
 Build halted.
 EOF
@@ -975,10 +938,9 @@ echo 'Building the multiver test modules'
 set_signing_message "dkms_multiver_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_multiver_test -v 1.0 << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 run_status_with_expected_output 'dkms_multiver_test' << EOF
 dkms_multiver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -987,10 +949,9 @@ EOF
 set_signing_message "dkms_multiver_test" "2.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_multiver_test -v 2.0 << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 run_status_with_expected_output 'dkms_multiver_test' << EOF
 dkms_multiver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1000,13 +961,9 @@ EOF
 echo 'Installing the multiver test modules'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_multiver_test -v 1.0 << EOF
 
-dkms_multiver_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_multiver_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_multiver_test' << EOF
 dkms_multiver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
@@ -1014,13 +971,9 @@ dkms_multiver_test/2.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
 EOF
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_multiver_test -v 2.0 << EOF
 
-dkms_multiver_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - This kernel never originally had a module by this name
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_multiver_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_multiver_test' << EOF
 dkms_multiver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1028,11 +981,12 @@ dkms_multiver_test/2.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 run_with_expected_error 6 dkms install -k "${KERNEL_VER}" -m dkms_multiver_test -v 1.0 << EOF
 
-dkms_multiver_test.ko${mod_compression_ext}:
-Running module version sanity check.
+
 Error! Module version 1.0 for dkms_multiver_test.ko${mod_compression_ext}
 is not newer than what is already found in kernel ${KERNEL_VER} (2.0).
 You may override by specifying --force.
+
+
 Error! Installation aborted.
 EOF
 run_status_with_expected_output 'dkms_multiver_test' << EOF
@@ -1052,12 +1006,9 @@ run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_multiver_test
 Module dkms_multiver_test-2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_multiver_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_multiver_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_multiver_test' << EOF
 dkms_multiver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1137,10 +1088,9 @@ echo 'Building the nover/emptyver test modules'
 set_signing_message "dkms_nover_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_nover_test -v 1.0 << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 run_status_with_expected_output 'dkms_nover_test' << EOF
 dkms_nover_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1148,10 +1098,9 @@ EOF
 set_signing_message "dkms_emptyver_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_emptyver_test -v 1.0 << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 run_status_with_expected_output 'dkms_emptyver_test' << EOF
 dkms_emptyver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1160,26 +1109,18 @@ EOF
 echo 'Installing the nover/emptyver test modules'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_nover_test -v 1.0 << EOF
 
-dkms_nover_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_nover_test' << EOF
 dkms_nover_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_emptyver_test -v 1.0 << EOF
 
-dkms_emptyver_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_emptyver_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_emptyver_test' << EOF
 dkms_emptyver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
@@ -1190,12 +1131,9 @@ run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_nover_test -v
 Module dkms_nover_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_nover_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_nover_test' << EOF
 dkms_nover_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1208,12 +1146,9 @@ run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_emptyver_test
 Module dkms_emptyver_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_emptyver_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_emptyver_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_emptyver_test' << EOF
 dkms_emptyver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1273,18 +1208,13 @@ echo 'Installing the nover update test 1.0 modules'
 set_signing_message "dkms_nover_update_test" "1.0"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_nover_update_test -v 1.0 << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 
-dkms_nover_update_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_update_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_nover_update_test' << EOF
 dkms_nover_update_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
@@ -1307,18 +1237,13 @@ echo 'Installing the nover update test 2.0 modules'
 set_signing_message "dkms_nover_update_test" "2.0"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_nover_update_test -v 2.0 << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 
-dkms_nover_update_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - This kernel never originally had a module by this name
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_update_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_nover_update_test' << EOF
 dkms_nover_update_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1343,10 +1268,9 @@ echo 'Building the nover update test 3.0 modules'
 set_signing_message "dkms_nover_update_test" "3.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_nover_update_test -v 3.0 << EOF
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 run_status_with_expected_output 'dkms_nover_update_test' << EOF
 dkms_nover_update_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1358,18 +1282,15 @@ MODULE_PATH_2="/var/lib/dkms/dkms_nover_update_test/2.0/${KERNEL_VER}/${KERNEL_A
 MODULE_PATH_3="/var/lib/dkms/dkms_nover_update_test/3.0/${KERNEL_VER}/${KERNEL_ARCH}/module/dkms_nover_update_test.ko${mod_compression_ext}"
 if ! modinfo "${MODULE_PATH_3}" | grep -q '^srcversion:' && ! diff "${MODULE_PATH_2}" "${MODULE_PATH_3}" &>/dev/null; then
     # On debian, no srcversion in modinfo's output, the installation will always succeed
-    echo 'Notice: Skip installation test on this platform'
+    echo ' Notice: Skip installation test on this platform'
 else
-    echo 'Installing the nover update test 3.0 modules (expected error)'
+    echo ' Installing the nover update test 3.0 modules (expected error)'
     set_signing_message "dkms_nover_update_test" "3.0"
     run_with_expected_error 6 dkms install -k "${KERNEL_VER}" -m dkms_nover_update_test -v 3.0 << EOF
 
-dkms_nover_update_test.ko${mod_compression_ext}:
-Running module version sanity check.
-Module version  for dkms_nover_update_test.ko${mod_compression_ext}
-exactly matches what is already found in kernel ${KERNEL_VER}.
-DKMS will not replace this module.
-You may override by specifying --force.
+Module /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_update_test.ko${mod_compression_ext} already installed at version , override by specifying --force
+
+
 Error! Installation aborted.
 EOF
     run_status_with_expected_output 'dkms_nover_update_test' << EOF
@@ -1388,12 +1309,9 @@ run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_nover_update_tes
 Module dkms_nover_update_test-2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_nover_update_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_update_test.ko${mod_compression_ext}
+
+Running depmod... done.
 Deleting module dkms_nover_update_test-2.0 completely from the DKMS tree.
 EOF
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_nover_update_test -v 1.0 << EOF
@@ -1422,14 +1340,14 @@ EOF
 echo 'Running autoinstall with failing test module (expected error)'
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 
-Building module:
-Cleaning build area...
+Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
 make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} failed for dkms_failing_test(10)
+
 Error! One or more modules failed to install during autoinstall.
 Refer to previous errors for more information.
 EOF
@@ -1441,8 +1359,7 @@ EOF
 echo 'Running autoinstall with failing test module and test module with dependencies on the failing module (expected error)'
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 
-Building module:
-Cleaning build area...
+Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
 make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
@@ -1450,6 +1367,7 @@ Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARC
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} failed for dkms_failing_test(10)
 dkms_dependencies_test/1.0 autoinstall failed due to missing dependencies: dkms_failing_test
+
 Error! One or more modules failed to install during autoinstall.
 Refer to previous errors for more information.
 EOF
@@ -1466,6 +1384,7 @@ rm -r /usr/src/dkms_failing_test-1.0
 echo 'Running autoinstall with test module with missing dependencies (expected error)'
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 dkms_dependencies_test/1.0 autoinstall failed due to missing dependencies: dkms_failing_test
+
 Error! One or more modules failed to install during autoinstall.
 Refer to previous errors for more information.
 EOF
@@ -1540,18 +1459,13 @@ for module dkms_build_exclusive_test includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 
-dkms_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} succeeded for dkms_test
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} was skipped for dkms_build_exclusive_test
 EOF
@@ -1567,12 +1481,9 @@ run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_test -v 1.0 << 
 Module dkms_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0: added
@@ -1590,29 +1501,24 @@ for module dkms_build_exclusive_test includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
 
-Building module:
-Cleaning build area...
+Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
 make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 
-dkms_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} succeeded for dkms_test
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} was skipped for dkms_build_exclusive_test
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} failed for dkms_failing_test(10)
+
 Error! One or more modules failed to install during autoinstall.
 Refer to previous errors for more information.
 EOF
@@ -1631,12 +1537,9 @@ run_with_expected_output dkms remove --all -m dkms_test -v 1.0 << EOF
 Module dkms_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 Deleting module dkms_test-1.0 completely from the DKMS tree.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -1725,6 +1628,7 @@ mv_osrelease "/usr/lib/os-release" "_usrlib-os-release"
 
 echo "Adding the dkms_test-1.0 module with no os-release files (expected error)"
 run_with_expected_error 4 dkms add test/dkms_test-1.0 << EOF
+
 Error! System is missing os-release file.
 EOF
 
@@ -1796,6 +1700,7 @@ rm /var/lib/dkms/dkms_test/1.0/source
 echo 'Checking broken status'
 run_with_expected_output dkms status dkms_test/1.0 << EOF
 dkms_test/1.0: broken
+
 Error! dkms_test/1.0: Missing the module source directory or the symbolic link pointing to it.
 Manual intervention is required!
 EOF
@@ -1810,6 +1715,7 @@ rm /var/lib/dkms/dkms_test/1.0/source
 
 echo 'Building broken test module (expected erorr)'
 run_with_expected_error 4 dkms build dkms_test/1.0 << EOF
+
 Error! dkms_test/1.0 is broken!
 Missing the source directory or the symbolic link pointing to it.
 Manual intervention is required!
@@ -1817,6 +1723,7 @@ EOF
 
 echo 'Installing broken test module (expected erorr)'
 run_with_expected_error 4 dkms install dkms_test/1.0 << EOF
+
 Error! dkms_test/1.0 is broken!
 Missing the source directory or the symbolic link pointing to it.
 Manual intervention is required!
@@ -1824,6 +1731,7 @@ EOF
 
 echo 'Unbuild broken test module (expected erorr)'
 run_with_expected_error 4 dkms unbuild dkms_test/1.0 << EOF
+
 Error! dkms_test/1.0 is broken!
 Missing the source directory or the symbolic link pointing to it.
 Manual intervention is required!
@@ -1831,6 +1739,7 @@ EOF
 
 echo 'Uninstall broken test module (expected erorr)'
 run_with_expected_error 4 dkms uninstall dkms_test/1.0 << EOF
+
 Error! dkms_test/1.0 is broken!
 Missing the source directory or the symbolic link pointing to it.
 Manual intervention is required!
@@ -1845,12 +1754,14 @@ echo 'Checking broken status'
 run_with_expected_output dkms status << EOF
 dkms_multiver_test/1.0: added
 dkms_test/1.0: broken
+
 Error! dkms_test/1.0: Missing the module source directory or the symbolic link pointing to it.
 Manual intervention is required!
 EOF
 
 echo 'Remove broken test module (expected erorr)'
 run_with_expected_error 4 dkms remove dkms_test/1.0 << EOF
+
 Error! dkms_test/1.0 is broken!
 Missing the source directory or the symbolic link pointing to it.
 Manual intervention is required!
@@ -1868,6 +1779,7 @@ echo 'Checking broken status'
 run_with_expected_output dkms status << EOF
 dkms_multiver_test/1.0: added
 dkms_test/1.0: broken
+
 Error! dkms_test/1.0: Missing the module source directory or the symbolic link pointing to it.
 Manual intervention is required!
 EOF
@@ -1883,10 +1795,9 @@ set_signing_message "dkms_test" "1.0"
 run_with_expected_output dkms build test/dkms_test-1.0 -k "${KERNEL_VER}" << EOF
 Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 
 echo 'Adding and building the multiver test module 1.0 by directory'
@@ -1894,10 +1805,9 @@ set_signing_message "dkms_multiver_test" "1.0"
 run_with_expected_output dkms build test/dkms_multiver_test/1.0 -k "${KERNEL_VER}" << EOF
 Creating symlink /var/lib/dkms/dkms_multiver_test/1.0/source -> /usr/src/dkms_multiver_test-1.0
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 
 echo ' Removing symlink /var/lib/dkms/dkms_multiver_test/1.0/source'
@@ -1908,28 +1818,25 @@ set_signing_message "dkms_multiver_test" "2.0"
 run_with_expected_output dkms build test/dkms_multiver_test/2.0 -k "${KERNEL_VER}" << EOF
 Creating symlink /var/lib/dkms/dkms_multiver_test/2.0/source -> /usr/src/dkms_multiver_test-2.0
 
-Building module:
-Cleaning build area...
-Building module(s)...
-${SIGNING_MESSAGE}Cleaning build area...
+Cleaning build area... done.
+Building module(s)... done.
+${SIGNING_MESSAGE}Cleaning build area... done.
 EOF
 
 echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+
 Error! dkms_multiver_test/1.0 is broken! Missing the source directory or the symbolic link pointing to it.
 Manual intervention is required!
 
-dkms_test.ko${mod_compression_ext}:
-Running module version sanity check.
- - Original module
-   - No original module exists within this kernel
- - Installation
-   - Installing to /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
-depmod...
+Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 dkms autoinstall on ${KERNEL_VER}/${KERNEL_ARCH} succeeded for dkms_test
 EOF
 run_with_expected_output dkms status << EOF
 dkms_multiver_test/1.0: broken
+
 Error! dkms_multiver_test/1.0: Missing the module source directory or the symbolic link pointing to it.
 Manual intervention is required!
 dkms_multiver_test/2.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
@@ -1942,12 +1849,9 @@ run_with_expected_output dkms remove dkms_test/1.0 -k "${KERNEL_VER}" << EOF
 Module dkms_test-1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}).
 Before uninstall, this module version was ACTIVE on this kernel.
 
-dkms_test.ko${mod_compression_ext}:
- - Uninstallation
-   - Deleting from: /lib/modules/${KERNEL_VER}/${expected_dest_loc}/
- - Original module
-   - No original module was found for this module on this kernel.
-   - Use the dkms install command to reinstall any previous module version.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
+Running depmod... done.
 Deleting module dkms_test-1.0 completely from the DKMS tree.
 EOF
 


### PR DESCRIPTION
The output when installing and uninstalling modules is unbelievably long, and in most cases it prints useless information.

Make some changes to print additional information only when relevant to the context and shorten output in general. List of commits, in order:

- Drop useless duplicate line when building.
- When a task is set into background, dots are used to show progress. Add a "`done.`" at the end of the dots when the task it's finished.
- Reduce output when installing and uninstalling. Contexts like "Uninstallation" and "Original module" are no longer printed and instead lines with the detail about the topic are printed only if they are relevant. So if everything is simple (one module, not present, etc.) not much is printed. One-line outpus ("Installation aborted" etc. are separated by one line.