### PR TITLE
Allow parallel_jobs to be set in framework.conf

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -813,6 +813,9 @@ can also be a "pkcs11:..." string for PKCS#11 engine, as long as the sign_file p
 .TP
 .B $modprobe_on_install
 Automatically load the built modules upon successful installation.
+.TP
+.B $parallel_jobs
+Run no more than this number of jobs in parallel.
 .SH dkms_autoinstaller
 This boot\-time service automatically installs any module which has
 .B AUTOINSTALL="yes"

--- a/dkms.in
+++ b/dkms.in
@@ -43,7 +43,7 @@ readonly dkms_conf_variables="CLEAN PACKAGE_NAME
 # All of the variables not related to signing we will accept from framework.conf.
 readonly dkms_framework_nonsigning_variables="source_tree dkms_tree install_tree tmp_location
    verbose symlink_modules autoinstall_all_kernels
-   modprobe_on_install"
+   modprobe_on_install parallel_jobs"
 # All of the signing related variables we will accept from framework.conf.
 readonly dkms_framework_signing_variables="sign_file mok_signing_key mok_certificate"
 

--- a/dkms_framework.conf.in
+++ b/dkms_framework.conf.in
@@ -43,3 +43,6 @@
 
 # Automatically modprobe the built modules upon successful installation:
 # modprobe_on_install="true"
+
+# Limit the number of jobs run in parallel (default is the number of CPUs)
+# parallel_jobs=2


### PR DESCRIPTION
The resolution to issue #265 limited the number of variables that dkms would accept from framework.conf. It is useful to be able to configure a system wide limit of the number of parallel tasks by dkms, and so this commit adds parallel_jobs to the permitted list.
