### PR TITLE
find_module:fix a mistake for kernel with modules uncompressed

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -228,7 +228,7 @@ find_module()
 {
     # tree = $1
     # module = $2
-    find "$1" -name "$2$module_uncompressed_suffix" -o -name "$2$module_suffix" -type f
+    find "$1" -name "$2$module_uncompressed_suffix" -type f -o -name "$2$module_suffix" -type f
     return $?
 }
 


### PR DESCRIPTION
For kernel with modules uncompressed,dkms find_module()'s command: find "$1" -name "$2$module_uncompressed_suffix" -o -name "$2$module_suffix" -type f actually turns out to be:
`find /lib/modules/[kerv] -name [module_name].ko -o -name [module_name].ko -type -f`

the "type -f" is used to include only for regular file, but with the command above, it only takes effect for the lastest "-name" match,and will get the symbolic files (are usually the symbolic files for weak_modules in /lib/*/weak-updates directory) by mistake.

For kernel with modules compressed the command turns out to be like: `find /lib/modules/[kerv] -name [module_name].ko -o -name [module_name].ko.xz -type -f` All the modules are with suffix ".xz",the first "-name" match actually do nothing so it's get nothing wrong.

Fix it by adding "-type -f" param after each "-name" option.