### PR TITLE
Update tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,19 +29,18 @@ jobs:
           - {name: "centos/centos", tag: "stream9", url: "quay.io/"}
           - {name: "debian", tag: "testing"}
           - {name: "debian", tag: "12"}
-          - {name: "debian", tag: "11"}
           - {name: "fedora/fedora", tag: "rawhide", url: "quay.io/"}
+          - {name: "fedora/fedora", tag: "41", url: "quay.io/"}
           - {name: "fedora/fedora", tag: "40", url: "quay.io/"}
           - {name: "fedora/fedora", tag: "39", url: "quay.io/"}
-          - {name: "gentoo/stage3", tag: "latest"}
           - {name: "opensuse/tumbleweed", tag: "latest", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "opensuse/leap", tag: "15.5", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "opensuse/leap", tag: "15.6", variant: "-default", url: "registry.opensuse.org/"}
+          - {name: "ubuntu", tag: "24.10"}
           - {name: "ubuntu", tag: "24.04"}
-          - {name: "ubuntu", tag: "23.10"}
           - {name: "ubuntu", tag: "22.04"}
           - {name: "ubuntu", tag: "20.04"}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.distro.url }}${{ matrix.distro.name }}:${{ matrix.distro.tag }}
 
@@ -73,13 +72,6 @@ jobs:
       run: |
         apt-get update -q
         apt-get install -qy make linux-headers-amd64 linux-image-amd64 openssl xz-utils
-
-    - name: Install Gentoo Linux dependencies
-      if: matrix.distro.name == 'gentoo/stage3'
-      run: |
-        echo -e "ACCEPT_KEYWORDS=\"~amd64\"\nACCEPT_LICENSE=\"*\"" >> /etc/portage/make.conf
-        emerge --sync
-        FEATURES="getbinpkg binpkg-ignore-signature" USE="generic-uki" emerge --noreplace -j$(nproc) -l$(nproc) --autounmask-continue '>=sys-kernel/gentoo-kernel-bin-6.6.0'
 
     - name: Install openSUSE leap dependencies
       if: contains(matrix.distro.name, 'opensuse')

--- a/run_test.sh
+++ b/run_test.sh
@@ -191,8 +191,6 @@ generalize_expected_output() {
     sed -i "/^ERROR (dkms apport): /d" ${output_log}
     # Drop empty lines
     sed -i "/^$/d" ${output_log}
-    # Gentoo complains there is not a .comment section in the built modules
-    sed -i "/^readelf\: Warning: Section '.comment' was not dumped because it does not exist$/d" ${output_log}
     # Swap any CC/LD/... flags (if set) with a placeholder message
     sed -i "s|\(make -j1 KERNELRELEASE=${KERNEL_VER} all\).*|\1 <omitting possibly set CC/LD/... flags>|" ${output_log}
 }


### PR DESCRIPTION
- Drop Debian 11 (EOL).
- Drop Ubuntu 23.10 (EOL).
- Add Fedora 41.
- Add Ubuntu 24.10.
- Switch `runs-on` to Ubuntu 24.04.
- Drop Gentoo; takes 30 minutes just to start the tests. Also, I don't quite get the Gentoo+DKMS combo, you rebuild the kernel, so along with that you rebuild the modules anyway.