### PR TITLE
Fix issue with stripped vmlinux and re-introduce Gentoo tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
           - {name: "fedora/fedora", tag: "41", url: "quay.io/"}
           - {name: "fedora/fedora", tag: "40", url: "quay.io/"}
           - {name: "fedora/fedora", tag: "39", url: "quay.io/"}
+          - {name: "gentoo/stage3", tag: "latest"}
           - {name: "opensuse/tumbleweed", tag: "latest", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "opensuse/leap", tag: "15.5", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "opensuse/leap", tag: "15.6", variant: "-default", url: "registry.opensuse.org/"}
@@ -72,6 +73,13 @@ jobs:
       run: |
         apt-get update -q
         apt-get install -qy make linux-headers-amd64 linux-image-amd64 openssl xz-utils
+
+    - name: Install Gentoo Linux dependencies
+      if: matrix.distro.name == 'gentoo/stage3'
+      run: |
+        echo -e "MAKEOPTS=\"-j$(nproc) -l$(nproc)\"\nACCEPT_LICENSE=\"*\"" >> /etc/portage/make.conf
+        wget --progress=dot:mega -O - https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz | tar -xz && mv gentoo-master /var/db/repos/gentoo
+        FEATURES="getbinpkg binpkg-ignore-signature parallel-fetch parallel-install pkgdir-index-trusted" USE="-initramfs" emerge --quiet --noreplace -j$(nproc) -l$(nproc) --autounmask-continue --with-bdeps=n '>=sys-kernel/gentoo-kernel-bin-6.6.0'
 
     - name: Install openSUSE leap dependencies
       if: contains(matrix.distro.name, 'opensuse')

--- a/dkms.in
+++ b/dkms.in
@@ -656,7 +656,7 @@ read_conf()
 
     # Check if clang was used to compile or lld was used to link the kernel.
     if [[ -e $kernel_source_dir/vmlinux ]]; then
-      if  readelf -p .comment $kernel_source_dir/vmlinux | grep -q clang; then
+      if  readelf -p .comment $kernel_source_dir/vmlinux 2>&1 | grep -q clang; then
         make_command="${make_command} LLVM=1"
       fi
     elif [[ -e "${kernel_config}" ]]; then


### PR DESCRIPTION
- silence complaints from `readelf` if, for example, the `.comment` section is missing from `vmlinux`. If readelf fails then we should always just continue with the second `.config` based check.
- re-introduce the tests for Gentoo with more optimizations for speed.

[EDIT] Gentoo tests now complete successfully after 4 minutes, I'd say that is quite fast.