### PR TITLE
allow configuring compression settings

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -823,6 +823,9 @@ Automatically load the built modules upon successful installation.
 .TP
 .B $parallel_jobs
 Run no more than this number of jobs in parallel.
+.TP
+.B $compress_gzip_opts, $compress_xz_opts, $compress_zstd_opts
+Control how modules are compressed. By default, the highest available level of compression is used.
 .SH dkms_autoinstaller
 This boot\-time service automatically installs any module which has
 .B AUTOINSTALL="yes"

--- a/dkms.in
+++ b/dkms.in
@@ -43,7 +43,8 @@ readonly dkms_conf_variables="CLEAN PACKAGE_NAME
 # All of the variables not related to signing we will accept from framework.conf.
 readonly dkms_framework_nonsigning_variables="source_tree dkms_tree install_tree tmp_location
    verbose symlink_modules autoinstall_all_kernels
-   modprobe_on_install parallel_jobs"
+   modprobe_on_install parallel_jobs
+   compress_gzip_opts compress_xz_opts compress_zstd_opts"
 # All of the signing related variables we will accept from framework.conf.
 readonly dkms_framework_signing_variables="sign_file mok_signing_key mok_certificate"
 
@@ -1212,11 +1213,11 @@ actual_build()
         fi
 
         if [[ $module_compressed_suffix = .gz ]]; then
-            gzip -9f "$built_module" || compressed_module=""
+            gzip $compress_gzip_opts -f "$built_module" || compressed_module=""
         elif [[ $module_compressed_suffix = .xz ]]; then
-            xz --check=crc32 --lzma2=dict=1MiB -f "$built_module" || compressed_module=""
+            xz $compress_xz_opts -f "$built_module" || compressed_module=""
         elif [[ $module_compressed_suffix = .zst ]]; then
-            zstd -q -f -T0 -19 "$built_module" || compressed_module=""
+            zstd $compress_zstd_opts -f "$built_module" || compressed_module=""
         fi
         if [[ -n $compressed_module ]]; then
             cp -f "$compressed_module" "$base_dir/module/${dest_module_name[$count]}$module_suffix" >/dev/null
@@ -2517,6 +2518,11 @@ install_tree="@MODDIR@"
 tmp_location=${TMPDIR:-/tmp}
 verbose=""
 symlink_modules=""
+
+# Set compression defaults
+compress_gzip_opts="-9"
+compress_xz_opts="--check=crc32 --lzma2=dict=1MiB"
+compress_zstd_opts="-q -T0 -19"
 
 # Check that we can write temporary files
 tmpfile=$(mktemp_or_die)

--- a/dkms_framework.conf.in
+++ b/dkms_framework.conf.in
@@ -46,3 +46,9 @@
 
 # Limit the number of jobs run in parallel (default is the number of CPUs)
 # parallel_jobs=2
+
+# Compression settings DKMS uses when compressing modules. The defaults are
+# tuned for maximum compression at the expense of speed when compressing.
+# compress_gzip_opts="-9"
+# compress_xz_opts="--check=crc32 --lzma2=dict=1MiB"
+# compress_zstd_opts="-q -T0 -19"


### PR DESCRIPTION
This PR adds 3 new options to framework.conf to allow setting the flags used for each compression method. The current compression flags are kept as the defaults to avoid breaking any installs with suddenly larger module sizes.

This PR fixes #455 