### PR TITLE
Keep the Module.symvers file along with the module files if it exists.

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1202,6 +1202,9 @@ actual_build()
 
     # Save a copy of the new module
     mkdir "$base_dir/module" >/dev/null
+    if [ -f "$build_dir/Module.symvers" ] ; then
+        cp -f "$build_dir/Module.symvers" "$base_dir/module/Module.symvers"
+    fi
     for ((count=0; count < ${#built_module_name[@]}; count++)); do
         local the_module
         local built_module


### PR DESCRIPTION
As discussed in issue 423 https://github.com/dell/dkms/issues/423, this patch copies any generated Module.symvers file to the same location as the kernel module files (*.ko or other) will be copied.