### PR TITLE
install 'common.postinst' for install-redhat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ ifneq (,$(DESTDIR))
 endif
 	install -D -m 0644 dkms.service $(DESTDIR)$(SYSTEMD)/dkms.service
 	install -D -m 0755 redhat_kernel_install.d $(DESTDIR)$(KINSTALL)/40-dkms.install
+	install -D -m 0755 dkms_common.postinst $(DESTDIR)$(LIBDIR)/common.postinst
 
 install-debian: install
 	$(if $(strip $(SHAREDIR)),$(error Setting SHAREDIR is not supported))


### PR DESCRIPTION
In commit dacf2a8b3d6effbd4a10f9cfcecf52f732c5476a "Adjust installation for Red Hat based distributions" file "common.postinst" was lost.

But some packages with kernel modules for Red Hat based distributions use it to build the module during installation. As a result of the loss of the %post script file, the module sections end with an error code, and the module is not being built or installed.
Return the script to maintain compatibility.