### PR TITLE
Check for include/config/auto.conf by default in place of .config

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -304,20 +304,21 @@ it is assumed to be located in
 See below for more information on the format of
 .I dkms.conf.
 .TP
-.B \-\-config <kernel\-.config\-location>
+.B \-\-config <kernel\-include/config/auto.conf\-location>
 During a
 .B build
-this option is used to specify an alternate location for the kernel .config
-file which was used to compile that kernel. Normally,
+this option is used to specify an alternate location for the kernel
+.I include/config/auto.conf
+configuration file which contains that kernel configuration. Normally,
 .B dkms
-uses the Red Hat standard location and config filenames located in
-.I /usr/src/linux\-<kernel>/configs/.
-If the config for the kernel that you
-are building a module for is not located here or does not have the expected
-name in this location, you will need to tell
+is able to derive the location of the configuration file from the filesystem, but if there is a problem
+in the detection, you will need to tell
 .B dkms
-where the necessary .config can be found so that your kernel can be properly
-prepared for the module build.
+where the necessary
+.I include/config/auto.conf file
+(or the legacy
+.I .config
+file) can be found so that your kernel can be properly prepared for the module build.
 .TP
 .B \-\-archive <tarball\-location>
 This option is used during a

--- a/dkms.in
+++ b/dkms.in
@@ -252,7 +252,7 @@ show_usage()
     echo "  [options] = [-m module] [-v module-version] [-k kernel-version] [-a arch]"
     echo "              [-c dkms.conf-location] [-q] [--force] [--force-version-override] [--all]"
     echo "              [--templatekernel=kernel] [--directive='cli-directive=cli-value']"
-    echo "              [--config=kernel-.config-location] [--archive=tarball-location]"
+    echo "              [--config=kernel-include/config/auto.conf-location] [--archive=tarball-location]"
     echo "              [--kernelsourcedir=source-location] [--rpm_safe_upgrade]"
     echo "              [--dkmstree path] [--sourcetree path] [--installtree path]"
     echo "              [--binaries-only] [--source-only] [--verbose]"
@@ -336,7 +336,11 @@ set_kernel_source_dir_and_kconfig()
         kernel_source_dir="$(_get_kernel_dir "$1")"
     fi
     if [[ -z "${kconfig_fromcli}" ]]; then
-        kernel_config="${kernel_source_dir}/.config"
+        if [[ -e "${kernel_source_dir}/include/config/auto.conf" ]]; then
+            kernel_config="${kernel_source_dir}/include/config/auto.conf"
+        else
+            kernel_config="${kernel_source_dir}/.config"
+        fi
     fi
 }
 


### PR DESCRIPTION
Fix for https://github.com/dell/dkms/issues/464.

This changes the default check for the `include/config/auto.conf` file, which replaces the legacy `.config` file recently removed. Update man page accordingly.

Please note that some distributions (ex. Fedora) still ship the `.config` file, but this is not the standard and since 4.19 `auto.conf` is guaranteed to exist.