### PR TITLE
move kernel_prerm.d logic into dkms

### DIFF
--- a/debian_kernel_postinst.d.in
+++ b/debian_kernel_postinst.d.in
@@ -3,27 +3,6 @@
 # We're passed the version of the kernel being installed
 inst_kern=$1
 
-uname_s=$(uname -s)
-
-_get_kernel_dir() {
-    KVER=$1
-    DIR="@MODDIR@/$KVER/build"
-    echo "$DIR"
-}
-
-_check_kernel_dir() {
-    DIR=$(_get_kernel_dir "$1")
-    test -e "$DIR/include"
-}
-
-header_pkg="linux-headers-$inst_kern"
-kernel="Linux"
-
 if [ -x @LIBDIR@/dkms_autoinstaller ]; then
     exec @LIBDIR@/dkms_autoinstaller start "$inst_kern"
-fi
-
-if ! _check_kernel_dir "$inst_kern" ; then
-    echo "dkms: WARNING: $kernel headers are missing, which may explain the above failures." >&2
-    echo "      please install the $header_pkg package to fix this." >&2
 fi

--- a/debian_kernel_prerm.d.in
+++ b/debian_kernel_prerm.d.in
@@ -5,14 +5,7 @@
 inst_kern=$1
 
 if command -v dkms > /dev/null; then
-	dkms status -k "$inst_kern" 2>/dev/null | while IFS=",:/ " read -r name vers _ arch status; do
-		[ "$status" = "installed" ] || [ "$status" = "built" ] || continue
-		dkms unbuild -m "$name" -v "$vers" -k "$inst_kern" -a "$arch"
-	done
+    dkms kernel_prerm -k "$inst_kern"
 fi
-
-rmdir --ignore-fail-on-non-empty \
-	"@MODDIR@/$inst_kern/updates/dkms" \
-	"@MODDIR@/$inst_kern/updates" 2>/dev/null
 
 exit 0

--- a/debian_kernel_prerm.d.in
+++ b/debian_kernel_prerm.d.in
@@ -7,15 +7,6 @@ inst_kern=$1
 if command -v dkms > /dev/null; then
 	dkms status -k "$inst_kern" 2>/dev/null | while IFS=",:/ " read -r name vers _ arch status; do
 		[ "$status" = "installed" ] || [ "$status" = "built" ] || continue
-		echo "dkms: removing: $name/$vers ($inst_kern) ($arch)" >&2
-		# Compromise on using 'unbuild' to remove the module when a
-		# kernel is being removed.  The 'remove' command is too
-		# destructive.  The 'uninstall' command leaves built files
-		# around that have no other trigger to 'unbuild' them.
-		# (Triggering 'unbuild' on kernel header removal would not be
-		# a good idea because that would also cause the module to be
-		# uninstalled for the kernel, even though only the headers are
-		# being removed.)
 		dkms unbuild -m "$name" -v "$vers" -k "$inst_kern" -a "$arch"
 	done
 fi

--- a/dkms.in
+++ b/dkms.in
@@ -2563,6 +2563,7 @@ autoinstall() {
         for modv in "${to_install[@]}"; do
             IFS=/ read m v <<< "$modv"
             if [[ -z ${build_depends[$m]} ]]; then
+                echo "Autoinstall of module $m/$v for kernel $kernelver ($arch)"
                 (module="$m" module_version="$v" kernelver="$kernelver" arch="$arch" install_module)
                 status=$?
                 if (( status == 0 )); then

--- a/dkms.in
+++ b/dkms.in
@@ -1752,7 +1752,11 @@ do_uninstall()
     run_build_script post_remove "$post_remove"
 
     # Run depmod because we changed $install_tree
-    invoke_command "do_depmod $1" "Running depmod" '' background
+    if [[ ! $delayed_depmod ]]; then
+        invoke_command "do_depmod $1" "Running depmod" '' background
+    else
+        touch $dkms_tree/depmod-pending-$1-$2
+    fi
 
     # Delete the original_module if nothing for this kernel is installed anymore
     if [[ $was_active && -d $dkms_tree/$module/original_module/$1/$2 && ! -d $dkms_tree/$module/original_module/$1/$2/collisions ]]; then
@@ -2623,11 +2627,20 @@ kernel_prerm()
 
     have_one_kernel kernel_prerm
 
+    # run depmod only once after uninstalling all dkms modules
+    delayed_depmod=1
+
     while IFS='/' read m v; do
         is_module_built "$m" "$v" "$kernelver" "$arch" || continue
         echo "dkms: removing module $m/$v for kernel $kernelver ($arch)" >&2
         (module="$m" module_version="$v" unbuild_module) || failed="$failed $m/$v($?)"
     done < <(list_module_version_combos)
+
+    if [[ -f $dkms_tree/depmod-pending-$kernelver-$arch ]]; then
+        rm -f $dkms_tree/depmod-pending-$kernelver-$arch
+        invoke_command "do_depmod $1" "Running depmod" '' background
+    fi
+    delayed_depmod=
 
     # clean leftover empty directories
     [[ ! -d $install_tree/$kernelver ]] || find "$install_tree/$kernelver" -type d -empty -delete
@@ -2710,6 +2723,7 @@ die_is_fatal="yes"
 [ -x /sbin/weak-modules ] && weak_modules='/sbin/weak-modules'
 [ -x /usr/lib/module-init-tools/weak-modules ] && weak_modules='/usr/lib/module-init-tools/weak-modules'
 no_depmod=""
+delayed_depmod=""
 
 action_re='^(remove|(auto|un)?install|match|mktarball|(un)?build|add|status|ldtarball|generate_mok|kernel_prerm)$'
 

--- a/dkms.in
+++ b/dkms.in
@@ -1568,9 +1568,7 @@ is_module_added() {
 is_module_built() {
     [[ $1 && $2 && $3 && $4 ]] || return 1
     local d
-    local m
     d="$dkms_tree/$1/$2/$3/$4"
-    m=''
     [[ -d $d/module ]] || return 1
     local default_conf
     default_conf="$dkms_tree/$1/$2/source/dkms.conf"
@@ -1579,6 +1577,7 @@ is_module_built() {
     real_conf="${conf:-${default_conf}}"
     read_conf_or_die "$3" "$4" "$real_conf"
     set_module_suffix "$3"
+    local m
     for m in "${dest_module_name[@]}"; do
         local t
         t=$(compressed_or_uncompressed "$d/module" "$m")
@@ -1973,7 +1972,7 @@ module_status_built_extra() (
 )
 
 # Return a list of all the modules that are either built or installed.
-# This and module_status do some juggling of $IFS to ensure that
+# This and list_module_version_combos do some juggling of $IFS to ensure that
 # we do not get word splitting where it would be inconvenient.
 module_status_built() {
     local ret
@@ -2002,12 +2001,10 @@ module_status_built() {
     return $ret
 }
 
-# Return the status of all modules that have been added, built, or installed.
-module_status() {
+# Return a list of all module/version combos known to DKMS.
+list_module_version_combos() {
     local ret
     local modv
-    local m
-    local v
     local directory
     local oifs
     ret=1
@@ -2015,16 +2012,30 @@ module_status() {
     IFS=''
     for directory in "$dkms_tree/"${1:-*}/${2:-*}; do
         IFS="$oifs"
+        [[ -d $directory ]] || continue
         modv="${directory#$dkms_tree/}"
-        m="${modv%/*}"
-        v="${modv#*/}"
+        # skip <module>/kernel-<kver>-<karch> -> <modver>/<kver>/<karch> symlinks
+        [[ $modv != */kernel-*-* ]] || continue
+        echo "$modv"
+        ret=0
+        IFS=''
+    done
+    IFS="$oifs"
+    return $ret
+}
+
+# Return the status of all modules that have been added, built, or installed.
+module_status() {
+    local ret
+    local m
+    local v
+    ret=1
+    while IFS='/' read m v; do
         is_module_broken "$m" "$v" && { echo "broken $m/$v"; continue; }
         is_module_added "$m" "$v" || continue
         ret=0
         module_status_built "$m" "$v" "$3" "$4" || echo "added $m/$v"
-        IFS=''
-    done
-    IFS="$oifs"
+    done < <(list_module_version_combos "$1" "$2")
     return $ret
 }
 

--- a/dkms.in
+++ b/dkms.in
@@ -2477,6 +2477,11 @@ add_source_tree() {
 # functionality, and makes it much easier to reinstall DKMS kernel modules
 # by hand if dkms_autoinstaller is not used.
 autoinstall() {
+    if [[ -f /etc/dkms/no-autoinstall ]]; then
+        echo "Automatic installation of modules has been disabled."
+        return
+    fi
+
     local status
     local mv
     local mvka

--- a/dkms.in
+++ b/dkms.in
@@ -73,6 +73,7 @@
 # 11: autoinstall: One or more modules failed to install during autoinstall.
 # 12: setup_kernels_arches(): Could not determine architecture.
 # 13: build: Aborting build of module ... for kernel ... due to missing BUILD_DEPENDS: ...
+# 14: kernel_prerm: dkms kernel_prerm for kernel ... failed for module(s) ...
 # 77: skipped due to BUILD_EXCLUSIVE
 # 101: install: pre_install failed, aborting install.
 
@@ -248,7 +249,8 @@ show_usage()
 {
     echo "Usage: $0 [action] [options]"
     echo "  [action]  = { add | remove | build | unbuild | install | uninstall | match |"
-    echo "               autoinstall | mktarball | ldtarball | status | generate_mok }"
+    echo "               autoinstall | mktarball | ldtarball | status | generate_mok |"
+    echo "               kernel_prerm }"
     echo "  [options] = [-m module] [-v module-version] [-k kernel-version] [-a arch]"
     echo "              [-c dkms.conf-location] [-q] [--force] [--force-version-override] [--all]"
     echo "              [--templatekernel=kernel] [--directive='cli-directive=cli-value']"
@@ -354,6 +356,7 @@ check_all_is_banned()
 # A little test function for DKMS commands that only work on one kernel.
 have_one_kernel() {
     if (( ${#kernelver[@]} != 1 )); then
+        [[ $1 = kernel_prerm ]] && die 4 "The action $1 requires exactly one kernel version parameter on the command line."
         die 4 "The action $1 does not support multiple kernel version parameters on the command line."
     fi
     check_all_is_banned $1
@@ -2602,6 +2605,36 @@ autoinstall() {
     fi
 }
 
+# This is roughly the inverse action to 'autoinstall'. It is supposed to be
+# called upon removal of a kernel to also remove all modules (including
+# those with AUTOINSTALL="") that were built or installed for that kernel.
+#
+# Compromise on using 'unbuild' to remove the module when a kernel is being
+# removed. The 'remove' command is too destructive. The 'uninstall' command
+# leaves built files around that have no other trigger to 'unbuild' them.
+# (Triggering 'unbuild' on kernel header removal would not be a good idea
+# because that would also cause the module to be uninstalled for the kernel,
+# even though only the headers are being removed.)
+kernel_prerm()
+{
+    local m
+    local v
+    local failed
+
+    have_one_kernel kernel_prerm
+
+    while IFS='/' read m v; do
+        is_module_built "$m" "$v" "$kernelver" "$arch" || continue
+        echo "dkms: removing module $m/$v for kernel $kernelver ($arch)" >&2
+        (module="$m" module_version="$v" unbuild_module) || failed="$failed $m/$v($?)"
+    done < <(list_module_version_combos)
+
+    # clean leftover empty directories
+    [[ ! -d $install_tree/$kernelver ]] || find "$install_tree/$kernelver" -type d -empty -delete
+
+    [[ -z $failed ]] || die 14 "dkms kernel_prerm for kernel $kernelver ($arch) failed for module(s)$failed."
+}
+
 #############################
 ####                     ####
 #### Program Starts Here ####
@@ -2678,7 +2711,7 @@ die_is_fatal="yes"
 [ -x /usr/lib/module-init-tools/weak-modules ] && weak_modules='/usr/lib/module-init-tools/weak-modules'
 no_depmod=""
 
-action_re='^(remove|(auto|un)?install|match|mktarball|(un)?build|add|status|ldtarball|generate_mok)$'
+action_re='^(remove|(auto|un)?install|match|mktarball|(un)?build|add|status|ldtarball|generate_mok|kernel_prerm)$'
 
 # Parse command line arguments
 while (($# > 0)); do
@@ -2858,6 +2891,9 @@ parallel_jobs=${parallel_jobs:-$(get_num_cpus)}
 # Make sure we're not passing -j0 to make; treat -j0 as just "-j"
 [[ "$parallel_jobs" = 0 ]] && parallel_jobs=""
 
+# Require explicit --kernelver argument
+[[ $action = kernel_prerm ]] && have_one_kernel "$action"
+
 setup_kernels_arches "$action"
 case "$action" in
 remove | unbuild | uninstall)
@@ -2897,6 +2933,9 @@ ldtarball) # Make sure they're root if we're using --force
 generate_mok)
     read_framework_conf $dkms_framework_signing_variables
     prepare_mok
+    ;;
+kernel_prerm)
+    check_root && have_one_kernel "$action" && "$action"
     ;;
 *)
     error "Unknown action specified: \"$action\""

--- a/dkms.in
+++ b/dkms.in
@@ -250,7 +250,7 @@ show_usage()
     echo "Usage: $0 [action] [options]"
     echo "  [action]  = { add | remove | build | unbuild | install | uninstall | match |"
     echo "               autoinstall | mktarball | ldtarball | status | generate_mok |"
-    echo "               kernel_prerm }"
+    echo "               kernel_postinst | kernel_prerm }"
     echo "  [options] = [-m module] [-v module-version] [-k kernel-version] [-a arch]"
     echo "              [-c dkms.conf-location] [-q] [--force] [--force-version-override] [--all]"
     echo "              [--templatekernel=kernel] [--directive='cli-directive=cli-value']"
@@ -356,7 +356,7 @@ check_all_is_banned()
 # A little test function for DKMS commands that only work on one kernel.
 have_one_kernel() {
     if (( ${#kernelver[@]} != 1 )); then
-        [[ $1 = kernel_prerm ]] && die 4 "The action $1 requires exactly one kernel version parameter on the command line."
+        [[ $1 =~ kernel_(postinst|prerm) ]] && die 4 "The action $1 requires exactly one kernel version parameter on the command line."
         die 4 "The action $1 does not support multiple kernel version parameters on the command line."
     fi
     check_all_is_banned $1
@@ -2609,6 +2609,18 @@ autoinstall() {
     fi
 }
 
+# A wrapper for 'autoinstall', to be used in combination with 'kernel_prerm'.
+kernel_postinst()
+{
+    local m
+    local v
+    local failed
+
+    have_one_kernel kernel_postinst
+
+    autoinstall
+}
+
 # This is roughly the inverse action to 'autoinstall'. It is supposed to be
 # called upon removal of a kernel to also remove all modules (including
 # those with AUTOINSTALL="") that were built or installed for that kernel.
@@ -2725,7 +2737,7 @@ die_is_fatal="yes"
 no_depmod=""
 delayed_depmod=""
 
-action_re='^(remove|(auto|un)?install|match|mktarball|(un)?build|add|status|ldtarball|generate_mok|kernel_prerm)$'
+action_re='^(remove|(auto|un)?install|match|mktarball|(un)?build|add|status|ldtarball|generate_mok|kernel_(postinst|prerm))$'
 
 # Parse command line arguments
 while (($# > 0)); do
@@ -2906,7 +2918,7 @@ parallel_jobs=${parallel_jobs:-$(get_num_cpus)}
 [[ "$parallel_jobs" = 0 ]] && parallel_jobs=""
 
 # Require explicit --kernelver argument
-[[ $action = kernel_prerm ]] && have_one_kernel "$action"
+[[ $action =~ kernel_(postinst|prerm) ]] && have_one_kernel "$action"
 
 setup_kernels_arches "$action"
 case "$action" in
@@ -2948,7 +2960,7 @@ generate_mok)
     read_framework_conf $dkms_framework_signing_variables
     prepare_mok
     ;;
-kernel_prerm)
+kernel_postinst | kernel_prerm)
     check_root && have_one_kernel "$action" && "$action"
     ;;
 *)

--- a/dkms.in
+++ b/dkms.in
@@ -1520,7 +1520,7 @@ do_install()
         exit 6
     }
 
-    if [[ $modprobe_on_install ]]; then
+    if [[ $modprobe_on_install ]] && [[ $kernelver = "$(uname -r)" ]]; then
         # Make the newly installed modules available immediately
         find /sys/devices -name modalias -print0 | xargs -0 cat | sort -u | xargs modprobe -a -b -q
         if [[ -f /lib/systemd/system/systemd-modules-load.service ]]; then

--- a/dkms_autoinstaller.in
+++ b/dkms_autoinstaller.in
@@ -51,9 +51,7 @@ case "$1" in
 		else
 			kernel=$(uname -r)
 		fi
-		if [ -f /etc/dkms/no-autoinstall ]; then
-			echo "Automatic installation of modules has been disabled."
-		elif ! _check_kernel_dir $kernel; then
+		if ! _check_kernel_dir $kernel; then
 			echo "Automatic installation of modules for kernel $kernel was skipped since the kernel headers for this kernel do not seem to be installed."
 		else
 			dkms autoinstall --kernelver $kernel

--- a/redhat_kernel_install.d.in
+++ b/redhat_kernel_install.d.in
@@ -5,12 +5,9 @@ KERNEL_VERSION=$2
 
 case "$COMMAND" in
     add)
-            dkms autoinstall --kernelver $KERNEL_VERSION
+        dkms kernel_postinst --kernelver $KERNEL_VERSION
         ;;
     remove)
-        dkms status -k "$KERNEL_VERSION" 2>/dev/null | while IFS=",:/ " read -r name vers _ arch status; do
-            dkms unbuild -m "$name" -v "$vers" -k "$KERNEL_VERSION" -a "$arch"
-        done
-        find /usr/lib/modules/$KERNEL_VERSION -type d -empty -delete
+        dkms kernel_prerm --kernelver $KERNEL_VERSION
         ;;
 esac

--- a/redhat_kernel_install.d.in
+++ b/redhat_kernel_install.d.in
@@ -5,11 +5,7 @@ KERNEL_VERSION=$2
 
 case "$COMMAND" in
     add)
-        if [ -f /etc/dkms/no-autoinstall ]; then
-            echo "Automatic installation of modules has been disabled."
-        else
             dkms autoinstall --kernelver $KERNEL_VERSION
-        fi
         ;;
     remove)
         dkms status -k "$KERNEL_VERSION" 2>/dev/null | while IFS=",:/ " read -r name vers _ arch status; do

--- a/run_test.sh
+++ b/run_test.sh
@@ -983,7 +983,6 @@ dkms: removing module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KER
 Module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
-Running depmod... done.
 dkms: removing module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
@@ -1714,13 +1713,11 @@ post_remove: line 2/stderr
 post_remove: line 3
 post_remove: line 4/stderr
 post_remove: line 5
-Running depmod... done.
 dkms: removing module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
-Running depmod... done.
 dkms: removing module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):

--- a/run_test.sh
+++ b/run_test.sh
@@ -976,28 +976,30 @@ run_status_with_expected_output 'dkms_dependencies_test' << EOF
 dkms_dependencies_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 
-echo 'Unbuilding the test module with dependencies'
-run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_dependencies_test -v 1.0 << EOF
+echo 'Running dkms kernel_prerm'
+run_with_expected_output dkms kernel_prerm -k "${KERNEL_VER}" << EOF
+dkms: removing module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
 Running depmod... done.
-EOF
-run_status_with_expected_output 'dkms_test' << EOF
-dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
-EOF
-run_status_with_expected_output 'dkms_dependencies_test' << EOF
-dkms_dependencies_test/1.0: added
-EOF
-
-echo 'Unbuilding the prerequisite test module'
-run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
+dkms: removing module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+EOF
+run_status_with_expected_output 'dkms_test' << EOF
+dkms_test/1.0: added
+EOF
+run_status_with_expected_output 'dkms_dependencies_test' << EOF
+dkms_dependencies_test/1.0: added
+EOF
+
+echo 'Running dkms kernel_prerm again'
+run_with_expected_output dkms kernel_prerm -k "${KERNEL_VER}" << EOF
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0: added

--- a/run_test.sh
+++ b/run_test.sh
@@ -870,8 +870,17 @@ run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0: added
 EOF
 
-echo "Running dkms autoinstall"
-run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+echo 'Running dkms kernel_postinst w/o kernel argument (expected error)'
+run_with_expected_error 4 dkms kernel_postinst << EOF
+
+Error! The action kernel_postinst requires exactly one kernel version parameter on the command line.
+EOF
+run_status_with_expected_output 'dkms_test' << EOF
+dkms_test/1.0: added
+EOF
+
+echo "Running dkms kernel_postinst"
+run_with_expected_output dkms kernel_postinst -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -880,6 +889,13 @@ ${SIGNING_MESSAGE}Cleaning build area... done.
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test.
+EOF
+run_status_with_expected_output 'dkms_test' << EOF
+dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
+EOF
+
+echo "Running dkms kernel_postinst again"
+run_with_expected_output dkms kernel_postinst -k "${KERNEL_VER}" << EOF
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed

--- a/run_test.sh
+++ b/run_test.sh
@@ -1412,7 +1412,7 @@ check_no_dkms_test
 echo '*** Testing multiple dkms modules and more dkms features'
 ############################################################################
 
-echo ' Adding test module with patches'
+echo 'Adding test module with patches'
 run_with_expected_output dkms add test/dkms_patches_test-1.0 << EOF
 Creating symlink /var/lib/dkms/dkms_patches_test/1.0/source -> /usr/src/dkms_patches_test-1.0
 EOF
@@ -1421,7 +1421,7 @@ run_status_with_expected_output 'dkms_patches_test' << EOF
 dkms_patches_test/1.0: added
 EOF
 
-echo ' Building and installing the test module with patches'
+echo 'Building and installing the test module with patches'
 set_signing_message "dkms_patches_test" "1.0"
 SIGNING_MESSAGE_patches="$SIGNING_MESSAGE"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_patches_test -v 1.0 << EOF
@@ -1443,7 +1443,7 @@ run_status_with_expected_output 'dkms_patches_test' << EOF
 dkms_patches_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 
-echo ' Unbuilding the test module with patches'
+echo 'Unbuilding the test module with patches'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_patches_test -v 1.0 << EOF
 
 Module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
@@ -1455,7 +1455,7 @@ run_status_with_expected_output 'dkms_patches_test' << EOF
 dkms_patches_test/1.0: added
 EOF
 
-echo ' Adding test module with pre/post scripts'
+echo 'Adding test module with pre/post scripts'
 run_with_expected_output dkms add test/dkms_scripts_test-1.0 << EOF
 Creating symlink /var/lib/dkms/dkms_scripts_test/1.0/source -> /usr/src/dkms_scripts_test-1.0
 
@@ -1466,7 +1466,7 @@ run_status_with_expected_output 'dkms_scripts_test' << EOF
 dkms_scripts_test/1.0: added
 EOF
 
-echo ' Building and installing the test module with pre/post scripts'
+echo 'Building and installing the test module with pre/post scripts'
 set_signing_message "dkms_scripts_test" "1.0"
 SIGNING_MESSAGE_scripts="$SIGNING_MESSAGE"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
@@ -1490,7 +1490,7 @@ run_status_with_expected_output 'dkms_scripts_test' << EOF
 dkms_scripts_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 
-echo ' Unbuilding the test module with pre/post scripts'
+echo 'Unbuilding the test module with pre/post scripts'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
 
 Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
@@ -1504,7 +1504,7 @@ run_status_with_expected_output 'dkms_scripts_test' << EOF
 dkms_scripts_test/1.0: added
 EOF
 
-echo ' Adding noisy test module'
+echo 'Adding noisy test module'
 run_with_expected_output dkms add test/dkms_noisy_test-1.0 << EOF
 Creating symlink /var/lib/dkms/dkms_noisy_test/1.0/source -> /usr/src/dkms_noisy_test-1.0
 
@@ -1521,7 +1521,7 @@ run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0: added
 EOF
 
-echo ' Building and installing the noisy test module'
+echo 'Building and installing the noisy test module'
 set_signing_message "dkms_noisy_test" "1.0"
 SIGNING_MESSAGE_noisy="$SIGNING_MESSAGE"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_noisy_test -v 1.0 << EOF
@@ -1577,7 +1577,7 @@ run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 
-echo ' Unbuilding the noisy test module'
+echo 'Unbuilding the noisy test module'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_noisy_test -v 1.0 << EOF
 
 Module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
@@ -1597,7 +1597,7 @@ run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0: added
 EOF
 
-echo " Running dkms autoinstall with multiple modules"
+echo "Running dkms autoinstall with multiple modules"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}applying patch patch2.patch...patching file Makefile
 patching file dkms_noisy_test.c
@@ -1686,7 +1686,7 @@ run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 
-echo " Running dkms autoinstall again with multiple modules"
+echo "Running dkms autoinstall again with multiple modules"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 EOF
 run_status_with_expected_output 'dkms_patches_test' << EOF
@@ -1699,33 +1699,9 @@ run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 
-echo ' Unbuilding the test modules'
-
-run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_patches_test -v 1.0 << EOF
-
-Module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
-Before uninstall, this module version was ACTIVE on this kernel.
-Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
-Running depmod... done.
-EOF
-run_status_with_expected_output 'dkms_patches_test' << EOF
-dkms_patches_test/1.0: added
-EOF
-
-run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
-
-Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
-Before uninstall, this module version was ACTIVE on this kernel.
-Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
-
-Running the post_remove script:
-Running depmod... done.
-EOF
-run_status_with_expected_output 'dkms_scripts_test' << EOF
-dkms_scripts_test/1.0: added
-EOF
-
-run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_noisy_test -v 1.0 << EOF
+echo 'Running dkms kernel_prerm'
+run_with_expected_output dkms kernel_prerm -k "${KERNEL_VER}" << EOF
+dkms: removing module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
@@ -1739,12 +1715,45 @@ post_remove: line 3
 post_remove: line 4/stderr
 post_remove: line 5
 Running depmod... done.
+dkms: removing module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
+
+Module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
+Before uninstall, this module version was ACTIVE on this kernel.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
+Running depmod... done.
+dkms: removing module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
+
+Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
+Before uninstall, this module version was ACTIVE on this kernel.
+Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
+
+Running the post_remove script:
+Running depmod... done.
+EOF
+run_status_with_expected_output 'dkms_patches_test' << EOF
+dkms_patches_test/1.0: added
+EOF
+run_status_with_expected_output 'dkms_scripts_test' << EOF
+dkms_scripts_test/1.0: added
 EOF
 run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0: added
 EOF
 
-echo ' Removing the test module with patches'
+echo 'Running dkms kernel_prerm again'
+run_with_expected_output dkms kernel_prerm -k "${KERNEL_VER}" << EOF
+EOF
+run_status_with_expected_output 'dkms_patches_test' << EOF
+dkms_patches_test/1.0: added
+EOF
+run_status_with_expected_output 'dkms_scripts_test' << EOF
+dkms_scripts_test/1.0: added
+EOF
+run_status_with_expected_output 'dkms_noisy_test' << EOF
+dkms_noisy_test/1.0: added
+EOF
+
+echo 'Removing the test module with patches'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_patches_test -v 1.0 << EOF
 Module dkms_patches_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
 Module dkms_patches_test/1.0 is not built for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
@@ -1754,7 +1763,7 @@ EOF
 run_status_with_expected_output 'dkms_patches_test' << EOF
 EOF
 
-echo ' Removing the test module with pre/post scripts'
+echo 'Removing the test module with pre/post scripts'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
 Module dkms_scripts_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
 Module dkms_scripts_test/1.0 is not built for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
@@ -1764,7 +1773,7 @@ EOF
 run_status_with_expected_output 'dkms_scripts_test' << EOF
 EOF
 
-echo ' Removing the noisy test module'
+echo 'Removing the noisy test module'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_noisy_test -v 1.0 << EOF
 Module dkms_noisy_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
 Module dkms_noisy_test/1.0 is not built for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...

--- a/run_test.sh
+++ b/run_test.sh
@@ -788,6 +788,16 @@ run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0: added
 EOF
 
+touch /etc/dkms/no-autoinstall
+echo "Running dkms autoinstall with /etc/dkms/no-autoinstall present"
+run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Automatic installation of modules has been disabled.
+EOF
+run_status_with_expected_output 'dkms_test' << EOF
+dkms_test/1.0: added
+EOF
+rm -f /etc/dkms/no-autoinstall
+
 echo "Running dkms autoinstall"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}

--- a/run_test.sh
+++ b/run_test.sh
@@ -767,6 +767,7 @@ EOF
 
 echo "Running dkms autoinstall (module already built)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
@@ -800,6 +801,7 @@ rm -f /etc/dkms/no-autoinstall
 
 echo "Running dkms autoinstall"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -822,6 +824,7 @@ EOF
 
 echo "Running dkms autoinstall for a kernel without headers installed (expected error)"
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}-noheaders" << EOF
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER}-noheaders (${KERNEL_ARCH})
 
 Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
 Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
@@ -891,6 +894,7 @@ EOF
 
 echo "Running dkms kernel_postinst"
 run_with_expected_output dkms kernel_postinst -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -957,6 +961,7 @@ EOF
 
 echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -986,6 +991,7 @@ EOF
 
 echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -1035,6 +1041,7 @@ EOF
 
 echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -1042,6 +1049,7 @@ ${SIGNING_MESSAGE}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -1360,6 +1368,7 @@ EOF
 
 echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_replace_test/2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -1624,6 +1633,7 @@ EOF
 
 echo "Running dkms autoinstall with multiple modules"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}applying patch patch2.patch...patching file Makefile
 patching file dkms_noisy_test.c
  done.
@@ -1671,6 +1681,7 @@ post_install: line 3
 post_install: line 4/stderr
 post_install: line 5
 Running depmod... done.
+Autoinstall of module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}applying patch patch1.patch...patching file Makefile
 patching file dkms_patches_test.c
  done.
@@ -1684,6 +1695,7 @@ ${SIGNING_MESSAGE_patches}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
 Running depmod... done.
+Autoinstall of module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Running the pre_build script:
 
@@ -2542,6 +2554,7 @@ EOF
 check_module_source_tree_created /usr/src/dkms_failing_test-1.0
 echo 'Running autoinstall with failing test module (expected error)'
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
@@ -2563,6 +2576,7 @@ EOF
 check_module_source_tree_created /usr/src/dkms_failing_dependencies_test-1.0
 echo 'Running autoinstall with failing test module and test module with dependencies on the failing module (expected error)'
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
@@ -2638,6 +2652,7 @@ EOF
 
 echo "Running dkms autoinstall (1 x skip)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
@@ -2659,10 +2674,12 @@ EOF
 
 echo "Running dkms autoinstall (1 x skip, 1 x pass)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -2700,10 +2717,12 @@ check_module_source_tree_created /usr/src/dkms_failing_test-1.0
 
 echo "Running dkms autoinstall (1 x skip, 1 x fail, 1 x pass) (expected error)"
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
+Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
@@ -2712,6 +2731,7 @@ make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
 
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
@@ -2763,10 +2783,12 @@ EOF
 
 echo "Running dkms autoinstall (2 x skip, with dependency)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
+Autoinstall of module dkms_build_exclusive_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_dependencies_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_dependencies_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
@@ -3036,6 +3058,7 @@ run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 
 Error! dkms_multiver_test/1.0 is broken! Missing the source directory or the symbolic link pointing to it.
 Manual intervention is required!
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.


### PR DESCRIPTION
this adds two new actions `kernel_postinst` (a wrapper for autoinstall) and `kernel_prerm` that are intended to be called from `kernel_*.d/dkms`  to move the prerm logic into dkms as well

I haven't done proper testing of the integration bits (the kernel_*.d changes) yet in my Debian dkms torture chroots, yet, and I won't be able to do them for the redhat side

naming etc. is open for discussion