### PR TITLE
DRAFT: Test modules sharing a symbol

### DIFF
--- a/test/dkms_dependencies_test-1.0/dkms_dependencies_test.c
+++ b/test/dkms_dependencies_test-1.0/dkms_dependencies_test.c
@@ -7,9 +7,12 @@
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("A Simple dkms test module");
 
+extern void dkms_test_exported_function(void);
+
 static int __init dkms_dependencies_test_init(void)
 {
     printk(KERN_INFO "DKMS Test Module -%s Loaded\n",DKMS_TEST_VER);
+    dkms_test_exported_function();
     return 0;
 }
 

--- a/test/dkms_test-1.0/dkms_test.c
+++ b/test/dkms_test-1.0/dkms_test.c
@@ -21,3 +21,10 @@ static void __exit dkms_test_cleanup(void)
 module_init(dkms_test_init);
 module_exit(dkms_test_cleanup);
 MODULE_VERSION(DKMS_TEST_VER);
+
+void dkms_test_exported_function(void)
+{
+    printk(KERN_INFO "Function exported by the dkms test module.\n");
+}
+
+EXPORT_SYMBOL_GPL(dkms_test_exported_function);


### PR DESCRIPTION
This does not work as expected, so I'm obviously missing something. Help welcome.
There are dkms modules out in the wild doing this, but I didn't have time to check them in detail.

```
...
*** Testing dkms modules with dependencies
Adding the prerequisite test module
Running dkms autoinstall
Adding test module with dependencies
Running dkms autoinstall
Error: command 'dkms autoinstall -k 6.11.7-amd64' returned status 11 instead of expected 0

Sign command: /lib/modules/6.11.7-amd64/build/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub

Cleaning build area... done.
Building module(s)...(bad exit status: 2)
Failed command:
make -j1 KERNELRELEASE=6.11.7-amd64 -C /lib/modules/6.11.7-amd64/build M=/var/lib/dkms/dkms_dependencies_test/1.0/build

Error! Bad return status for module build on kernel: 6.11.7-amd64 (x86_64)
Consult /var/lib/dkms/dkms_dependencies_test/1.0/build/make.log for more information.
Autoinstall on 6.11.7-amd64 succeeded for module(s) dkms_test.
Autoinstall on 6.11.7-amd64 failed for module(s) dkms_dependencies_test(10).

Error! One or more modules failed to install during autoinstall.
Refer to previous errors for more information.
```

```
DKMS make.log for dkms_dependencies_test/1.0 for kernel 6.11.7-amd64 (x86_64)
Mon Dec 16 23:00:16 UTC 2024
make: Entering directory '/usr/src/linux-headers-6.11.7-amd64'
  CC [M]  /var/lib/dkms/dkms_dependencies_test/1.0/build/dkms_dependencies_test.o
  MODPOST /var/lib/dkms/dkms_dependencies_test/1.0/build/Module.symvers
ERROR: modpost: "dkms_test_exported_function" [/var/lib/dkms/dkms_dependencies_test/1.0/build/dkms_dependencies_test.ko] undefined!
make[2]: *** [/usr/src/linux-headers-6.11.7-common/scripts/Makefile.modpost:145: /var/lib/dkms/dkms_dependencies_test/1.0/build/Module.symvers] Error 1
make[1]: *** [/usr/src/linux-headers-6.11.7-common/Makefile:1903: modpost] Error 2
make: *** [/usr/src/linux-headers-6.11.7-common/Makefile:236: __sub-make] Error 2
make: Leaving directory '/usr/src/linux-headers-6.11.7-amd64'
```