### PR TITLE
Fix #472, capture error output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
           - {name: "archlinux", tag: "latest", variant: "-lts"}
           - {name: "archlinux", tag: "latest", variant: "-zen"}
           - {name: "centos/centos", tag: "stream9", url: "quay.io/"}
+          - {name: "centos/centos", tag: "stream10", url: "quay.io/"}
           - {name: "debian", tag: "testing"}
           - {name: "debian", tag: "12"}
           - {name: "fedora/fedora", tag: "rawhide", url: "quay.io/"}

--- a/redhat_kernel_install.d.in
+++ b/redhat_kernel_install.d.in
@@ -10,5 +10,6 @@ case "$COMMAND" in
         ;;
     remove)
         dkms kernel_prerm --kernelver $KERNEL_VERSION
+        res=$?
         ;;
 esac

--- a/redhat_kernel_install.d.in
+++ b/redhat_kernel_install.d.in
@@ -6,6 +6,7 @@ KERNEL_VERSION=$2
 case "$COMMAND" in
     add)
         dkms kernel_postinst --kernelver $KERNEL_VERSION
+        res=$?
         ;;
     remove)
         dkms kernel_prerm --kernelver $KERNEL_VERSION


### PR DESCRIPTION
Capture error output on module build and let the DNF transaction continue.

Extra: Add CentOS Stream 10 tests now that the image is released officially.