### PR TITLE
Ensure autoinstall reads /etc/dkms/$module.conf

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -2532,7 +2532,7 @@ autoinstall() {
             continue
         fi
         # If the module does not want to be autoinstalled, skip it.
-        read_conf_or_die "$kernelver" "$arch" "$dkms_tree/$m/$v/source/dkms.conf"
+        module=$m module_version=$v read_conf_or_die "$kernelver" "$arch" "$dkms_tree/$m/$v/source/dkms.conf"
         if [[ ! $AUTOINSTALL ]]; then
             continue
         fi


### PR DESCRIPTION
"dkms autoinstall" does not obey `BUILD_DEPENDS` (and presumably `AUTOINSTALL`) directives when placed in `/etc/dkms/$module.conf`, causing unexpected ordering and build failures.

The `read_conf` family of routines rely upon variables `module` and `module_version` (possibly others?) being already suitably set. Arguably they shouldn't, but this is a minimal change that corrects autoinstall's `BUILD_DEPENDS` processing.

There may be other places where this is needed.

Tested against dkms 3.1.4