### PR TITLE
Set compression levels to upstream defaults

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -2691,9 +2691,9 @@ verbose=""
 symlink_modules=""
 
 # Set compression defaults
-compress_gzip_opts="-9"
-compress_xz_opts="--check=crc32 --lzma2=dict=1MiB"
-compress_zstd_opts="-q -T0 -19"
+compress_gzip_opts="-6"
+compress_xz_opts="--check=crc32 --lzma2=dict=1MiB -6"
+compress_zstd_opts="-q -T0 -3"
 
 # Check that we can write temporary files
 tmpfile=$(mktemp_or_die)

--- a/dkms_framework.conf.in
+++ b/dkms_framework.conf.in
@@ -51,6 +51,6 @@
 
 # Compression settings DKMS uses when compressing modules. The defaults are
 # tuned for maximum compression at the expense of speed when compressing.
-# compress_gzip_opts="-9"
-# compress_xz_opts="--check=crc32 --lzma2=dict=1MiB"
-# compress_zstd_opts="-q -T0 -19"
+# compress_gzip_opts="-6"
+# compress_xz_opts="--check=crc32 --lzma2=dict=1MiB -6"
+# compress_zstd_opts="-q -T0 -3"


### PR DESCRIPTION
Currently, the compression defaults are maxed out to maximize storage gains (except for xz which is set to default?), at the cost of taking minutes instead of seconds to compress.

There is previous conversation about this comparing zstd gains at max vs minimum - https://github.com/dell/dkms/issues/455

@skwerlman made a PR that that made the values configurable - https://github.com/dell/dkms/pull/456

This PR changes this configuration to upstream defaults, as suggested in the above discussion.

The suggestion also considered dropping the parameters altogether to just always adapt upstream defaults - it should be more user friendly for those that are trying to modify the configuration to have a set example.

This is likely to break setups where people are putting the modules on an undersized ESP (notably, when people reuse the 100MiB Windows ESP for /boot), so bumping the filesizes by a couple megabytes could tip the size over the max.  

Such people can either fix their ESP size, or more simply configure dkms to use the old values that sacrifice speed for space savings.