### PR TITLE
Improve output formatting

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -947,7 +947,6 @@ run_build_script() {
     esac
     run="$dkms_tree/$module/$module_version/$script_type/$2"
     if [[ -x ${run%% *} ]]; then
-        echo ""
         echo "Running the $1 script:"
         (
             cd "$dkms_tree/$module/$module_version/$script_type/"

--- a/dkms.in
+++ b/dkms.in
@@ -1088,6 +1088,9 @@ prepare_mok()
 
 prepare_signing()
 {
+    # Lazy source in signing related configuration
+    read_framework_conf $dkms_framework_signing_variables
+
     do_signing=0
 
     if [[ ! -f ${kernel_config} ]]; then
@@ -1341,8 +1344,6 @@ do_build()
 {
     set_kernel_source_dir_and_kconfig "$kernelver"
     prepare_kernel "$kernelver"
-    # Lazy source in signing related configuration
-    read_framework_conf $dkms_framework_signing_variables
     prepare_signing
     prepare_build
     actual_build

--- a/dkms.in
+++ b/dkms.in
@@ -1814,6 +1814,7 @@ uninstall_module()
 {
     local i
     for ((i=0; i < ${#kernelver[@]}; i++)); do
+        [[ $i = 0 ]] || echo ""
         maybe_uninstall_module "${kernelver[$i]}" "${arch[$i]}"
     done
 }
@@ -1832,6 +1833,7 @@ unbuild_module()
 {
     local i
     for ((i=0; i < ${#kernelver[@]}; i++)); do
+        [[ $i = 0 ]] || echo ""
         maybe_uninstall_module "${kernelver[$i]}" "${arch[$i]}"
         maybe_unbuild_module "${kernelver[$i]}" "${arch[$i]}"
     done
@@ -2579,6 +2581,7 @@ autoinstall() {
                 else
                     failed_modules[${#failed_modules[@]}]="$m($status)"
                 fi
+                echo ""
             else
                 next_install[${#next_install[@]}]="$modv"
             fi
@@ -2656,6 +2659,7 @@ kernel_prerm()
         is_module_built "$m" "$v" "$kernelver" "$arch" || continue
         echo "dkms: removing module $m/$v for kernel $kernelver ($arch)" >&2
         (module="$m" module_version="$v" unbuild_module) || failed="$failed $m/$v($?)"
+        echo ""
     done < <(list_module_version_combos)
 
     if [[ -f $dkms_tree/depmod-pending-$kernelver-$arch ]]; then

--- a/dkms.in
+++ b/dkms.in
@@ -1121,7 +1121,6 @@ prepare_signing()
             sign_file="$install_tree/$kernelver/build/scripts/sign-file"
         fi
     fi
-    echo ""
     echo "Sign command: $sign_file"
 
     if [[ ! -f ${sign_file} || ! -x ${sign_file} ]]; then
@@ -1345,6 +1344,7 @@ prepare_kernel_and_signing()
     set_kernel_source_dir_and_kconfig "$kernelver"
     prepare_kernel "$kernelver"
     prepare_signing
+    echo ""
 }
 
 do_build()

--- a/dkms.in
+++ b/dkms.in
@@ -1018,9 +1018,6 @@ add_module()
 prepare_kernel()
 {
     # $1 = kernel version to prepare
-    # $2 = arch to prepare
-
-    set_kernel_source_dir_and_kconfig "$1"
 
     # Check that kernel-source exists
     _check_kernel_dir "$1" || {
@@ -1343,7 +1340,7 @@ clean_build()
 do_build()
 {
     set_kernel_source_dir_and_kconfig "$kernelver"
-    prepare_kernel "$kernelver" "$arch"
+    prepare_kernel "$kernelver"
     # Lazy source in signing related configuration
     read_framework_conf $dkms_framework_signing_variables
     prepare_signing
@@ -2345,7 +2342,7 @@ run_match()
         return 0
     fi
 
-    prepare_kernel "$kernelver" "$arch"
+    prepare_kernel "$kernelver"
 
     # Iterate over the kernel_status and match kernel to the template_kernel
     while read template_line; do

--- a/dkms.in
+++ b/dkms.in
@@ -509,6 +509,7 @@ safe_source() {
     local to_source_file
     to_source_file="$1"; shift
     declare -a -r export_envs=("$@")
+    local -r CR=$(echo -e '\r')
     local tmpfile
     tmpfile=$(mktemp_or_die)
     ( exec >"$tmpfile"
@@ -517,7 +518,7 @@ safe_source() {
     # Remember, in bash 2.0 and greater all variables are really arrays.
     for _export_env in "${export_envs[@]}"; do
         for _i in $(eval echo \${!$_export_env[@]}); do
-            eval echo '$_export_env[$_i]=\"${'$_export_env'[$_i]}\"'
+            eval echo '$_export_env[$_i]=\"${'$_export_env'[$_i]%$CR}\"'
         done
     done
 

--- a/dkms.in
+++ b/dkms.in
@@ -1136,7 +1136,10 @@ prepare_signing()
 prepare_build()
 {
     # If the module has not been added, try to add it.
-    is_module_added "$module" "$module_version" || add_module
+    if ! is_module_added "$module" "$module_version" ; then
+        add_module
+        echo ""
+    fi
 
     local -r base_dir="$dkms_tree/$module/$module_version/$kernelver/$arch"
     local -r build_dir="$dkms_tree/$module/$module_version/build"

--- a/dkms.in
+++ b/dkms.in
@@ -1428,7 +1428,6 @@ do_install()
     local count
     lib_tree="$install_tree/$kernelver"
 
-    echo ""
     for ((count=0; count < ${#built_module_name[@]}; count++)); do
         # Check this version against what is already in the kernel
         check_version_sanity "$kernelver" "$arch" "$obsolete_by" "${dest_module_name[$count]}" || continue
@@ -1630,6 +1629,7 @@ maybe_install_module() (
     is_module_installed "$1" "$2" "$3" "$4" && {
         if [[ "$force" = "true" ]]; then
             do_uninstall "$3" "$4"
+            echo ""
         else
             echo "Module $1/$2 already installed on kernel $3 ($4), skip." \
                  "You may override by specifying --force."

--- a/dkms.in
+++ b/dkms.in
@@ -30,7 +30,6 @@
 # 1: check_rw_dkms_tree(): No write access to DKMS tree at ...
 # 1: mktemp_or_die(): Unable to make temporary file/directory.
 # 1: check_module_args(): Arguments <module> and <module-version> are not specified.
-# 1: prepare_kernel(): Your kernel headers for kernel ... cannot be found ...
 # 1: run_match(): Invalid number of parameters passed.
 # 1: global: If more than one arch is specified on the command line, then there "must be an equal number of kernel versions also specified (1:1 relationship).
 # 2: global: Unknown option: ...
@@ -74,6 +73,7 @@
 # 12: setup_kernels_arches(): Could not determine architecture.
 # 13: build: Aborting build of module ... for kernel ... due to missing BUILD_DEPENDS: ...
 # 14: kernel_prerm: dkms kernel_prerm for kernel ... failed for module(s) ...
+# 21: prepare_kernel(): Your kernel headers for kernel ... cannot be found ...
 # 77: skipped due to BUILD_EXCLUSIVE
 # 101: install: pre_install failed, aborting install.
 
@@ -1020,7 +1020,7 @@ prepare_kernel()
 
     # Check that kernel-source exists
     _check_kernel_dir "$1" || {
-        die 1 "Your kernel headers for kernel $1 cannot be found at $install_tree/$1/build or $install_tree/$1/source." \
+        die 21 "Your kernel headers for kernel $1 cannot be found at $install_tree/$1/build or $install_tree/$1/source." \
             "Please install the linux-headers-$1 package or use the --kernelsourcedir option to tell DKMS where it's located."
     }
 }

--- a/dkms.in
+++ b/dkms.in
@@ -1259,8 +1259,6 @@ actual_build()
     local -r build_dir="$dkms_tree/$module/$module_version/build"
     local -r build_log="$build_dir/make.log"
 
-    echo ""
-
     invoke_command "$clean" "Cleaning build area" '' background
     echo "DKMS make.log for $module/$module_version for kernel $kernelver ($arch)" >> "$build_log"
     date >> "$build_log"

--- a/dkms.in
+++ b/dkms.in
@@ -1703,7 +1703,6 @@ do_uninstall()
     # $1 = kernel version
     # $2 = arch
 
-    echo ""
     echo "Module $module/$module_version for kernel $1 ($2):"
 
     set_module_suffix "$1"

--- a/dkms.in
+++ b/dkms.in
@@ -1341,9 +1341,12 @@ clean_build()
 
 prepare_kernel_and_signing()
 {
+    [[ $prepared_kernel = "$kernelver/$arch" ]] && return
+
     set_kernel_source_dir_and_kconfig "$kernelver"
     prepare_kernel "$kernelver"
     prepare_signing
+    prepared_kernel="$kernelver/$arch"
     echo ""
 }
 
@@ -2568,6 +2571,7 @@ autoinstall() {
         for modv in "${to_install[@]}"; do
             IFS=/ read m v <<< "$modv"
             if [[ -z ${build_depends[$m]} ]]; then
+                is_module_built "$m" "$v" "$kernelver" "$arch" || prepare_kernel_and_signing
                 echo "Autoinstall of module $m/$v for kernel $kernelver ($arch)"
                 (module="$m" module_version="$v" kernelver="$kernelver" arch="$arch" install_module)
                 status=$?
@@ -2749,6 +2753,7 @@ die_is_fatal="yes"
 [ -x /usr/lib/module-init-tools/weak-modules ] && weak_modules='/usr/lib/module-init-tools/weak-modules'
 no_depmod=""
 delayed_depmod=""
+prepared_kernel="none"
 
 action_re='^(remove|(auto|un)?install|match|mktarball|(un)?build|add|status|ldtarball|generate_mok|kernel_(postinst|prerm))$'
 

--- a/dkms.in
+++ b/dkms.in
@@ -1340,11 +1340,16 @@ clean_build()
     rm -rf "$dkms_tree/$module/$module_version/build"
 }
 
-do_build()
+prepare_kernel_and_signing()
 {
     set_kernel_source_dir_and_kconfig "$kernelver"
     prepare_kernel "$kernelver"
     prepare_signing
+}
+
+do_build()
+{
+    prepare_kernel_and_signing
     prepare_build
     actual_build
     clean_build

--- a/dkms.in
+++ b/dkms.in
@@ -1861,11 +1861,11 @@ remove_module()
     for ((i=0; i < ${#kernelver[@]}; i++)); do
         maybe_uninstall_module "${kernelver[$i]}" "${arch[$i]}"
         maybe_unbuild_module "${kernelver[$i]}" "${arch[$i]}"
+        echo ""
     done
 
     # Delete the $module_version part of the tree if no other $module_version/$kernel_version dirs exist
     if ! find $dkms_tree/$module/$module_version/* -maxdepth 0 -type d 2>/dev/null | grep -Eqv "(build|tarball|driver_disk|rpm|deb|source)$"; then
-        echo ""
         echo "Deleting module $module/$module_version completely from the DKMS tree."
         rm -rf "$dkms_tree/$module/$module_version"
     fi

--- a/run_test.sh
+++ b/run_test.sh
@@ -692,6 +692,7 @@ run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << 
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -756,6 +757,7 @@ echo 'Building the test module by config file (combining add, build)'
 run_with_expected_output dkms build -k "${KERNEL_VER}" test/dkms_test-1.0/dkms.conf << EOF
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
+
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -1952,6 +1954,7 @@ ${SIGNING_PROLOGUE}
 dkms.conf: Warning! Zero modules specified.
 Creating symlink /var/lib/dkms/dkms_conf_test/1.0/source -> /usr/src/dkms_conf_test-1.0
 
+
 Cleaning build area... done.
 Building module(s)... done.
 Cleaning build area... done.
@@ -3058,6 +3061,7 @@ run_with_expected_output dkms build test/dkms_test-1.0 -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -3068,6 +3072,7 @@ set_signing_message "dkms_multiver_test" "1.0"
 run_with_expected_output dkms build test/dkms_multiver_test/1.0 -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_multiver_test/1.0/source -> /usr/src/dkms_multiver_test-1.0
+
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -3082,6 +3087,7 @@ set_signing_message "dkms_multiver_test" "2.0"
 run_with_expected_output dkms build test/dkms_multiver_test/2.0 -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_multiver_test/2.0/source -> /usr/src/dkms_multiver_test-2.0
+
 
 Cleaning build area... done.
 Building module(s)... done.

--- a/run_test.sh
+++ b/run_test.sh
@@ -577,7 +577,6 @@ fi
 
 echo 'Installing the test module again by force'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -619,7 +618,6 @@ fi
 
 echo 'Uninstalling the test module'
 run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -736,7 +734,6 @@ fi
 
 echo 'Removing the test module with --all'
 run_with_expected_output dkms remove --all -m dkms_test -v 1.0 << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -779,7 +776,6 @@ EOF
 
 echo 'Unbuilding the test module'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -847,7 +843,6 @@ EOF
 echo 'Running dkms kernel_prerm'
 run_with_expected_output dkms kernel_prerm -k "${KERNEL_VER}" << EOF
 dkms: removing module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -920,7 +915,6 @@ EOF
 
 echo 'Removing the test module with --all'
 run_with_expected_output dkms remove --all -m dkms_test -v 1.0 << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -1014,13 +1008,11 @@ EOF
 echo 'Running dkms kernel_prerm'
 run_with_expected_output dkms kernel_prerm -k "${KERNEL_VER}" << EOF
 dkms: removing module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-
 Module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
 
 dkms: removing module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -1083,7 +1075,6 @@ EOF
 
 echo 'Removing the test module with dependencies'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_dependencies_test -v 1.0 << EOF
-
 Module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
@@ -1099,7 +1090,6 @@ EOF
 
 echo 'Removing the prerequisite test module'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -1173,7 +1163,6 @@ EOF
 
 echo 'Unbuilding the test module with unsatisfied dependencies'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_dependencies_test -v 1.0 << EOF
-
 Module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
@@ -1266,7 +1255,6 @@ EOF
 
 echo 'Removing the test module with circular dependencies'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_circular_dependencies_test -v 1.0 << EOF
-
 Module dkms_circular_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_circular_dependencies_test.ko${mod_compression_ext}
@@ -1341,7 +1329,6 @@ EOF
 
 echo 'Unbuilding the replacement test module'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_replace_test -v 2.0 << EOF
-
 Module dkms_replace_test/2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -1399,7 +1386,6 @@ EOF
 
 echo 'Removing the replacement test module'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_replace_test -v 2.0 << EOF
-
 Module dkms_replace_test/2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -1425,7 +1411,6 @@ EOF
 
 echo 'Removing the to-be-replaced test module'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -1479,7 +1464,6 @@ EOF
 
 echo 'Unbuilding the test module with patches'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_patches_test -v 1.0 << EOF
-
 Module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
@@ -1525,7 +1509,6 @@ EOF
 
 echo 'Unbuilding the test module with pre/post scripts'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
-
 Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
@@ -1611,7 +1594,6 @@ EOF
 
 echo 'Unbuilding the noisy test module'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_noisy_test -v 1.0 << EOF
-
 Module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noisy_test.ko${mod_compression_ext}
@@ -1737,7 +1719,6 @@ EOF
 echo 'Running dkms kernel_prerm'
 run_with_expected_output dkms kernel_prerm -k "${KERNEL_VER}" << EOF
 dkms: removing module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-
 Module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noisy_test.ko${mod_compression_ext}
@@ -1751,13 +1732,11 @@ post_remove: line 4/stderr
 post_remove: line 5
 
 dkms: removing module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-
 Module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
 
 dkms: removing module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-
 Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
@@ -1867,7 +1846,6 @@ EOF
 
 echo 'Uninstalling the noautoinstall test module'
 run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_noautoinstall_test -v 1.0 << EOF
-
 Module dkms_noautoinstall_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noautoinstall_test.ko${mod_compression_ext}
@@ -1984,7 +1962,6 @@ EOF
 run_with_expected_output dkms remove --all -m dkms_conf_test -v 1.0 << EOF
 dkms.conf: Warning! Zero modules specified.
 dkms.conf: Warning! Zero modules specified.
-
 Module dkms_conf_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Running depmod... done.
@@ -2134,7 +2111,6 @@ EOF
 
 echo ' Removing the test module'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_duplicate_test -v 1.0 << EOF
-
 Module dkms_duplicate_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_duplicate_test.ko${mod_compression_ext}
@@ -2173,7 +2149,6 @@ EOF
 
 echo ' Removing the test module'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_crlf_test -v 1.0 << EOF
-
 Module dkms_crlf_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dos_test.ko${mod_compression_ext}
@@ -2273,7 +2248,6 @@ dkms_multiver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
 dkms_multiver_test/2.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_multiver_test -v 2.0 << EOF
-
 Module dkms_multiver_test/2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_multiver_test.ko${mod_compression_ext}
@@ -2388,7 +2362,6 @@ EOF
 
 echo 'Uninstalling the nover/emptyver test modules'
 run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_nover_test -v 1.0 << EOF
-
 Module dkms_nover_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_test.ko${mod_compression_ext}
@@ -2402,7 +2375,6 @@ if [[ -e "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_test.ko${mo
     exit 1
 fi
 run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_emptyver_test -v 1.0 << EOF
-
 Module dkms_emptyver_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_emptyver_test.ko${mod_compression_ext}
@@ -2550,7 +2522,6 @@ Module dkms_nover_update_test/3.0 is not installed for kernel ${KERNEL_VER} (${K
 Deleting module dkms_nover_update_test/3.0 completely from the DKMS tree.
 EOF
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_nover_update_test -v 2.0 << EOF
-
 Module dkms_nover_update_test/2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_update_test.ko${mod_compression_ext}
@@ -2731,7 +2702,6 @@ EOF
 
 echo 'Unbuilding the test module'
 run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -2793,7 +2763,6 @@ remove_module_source_tree /usr/src/dkms_failing_test-1.0
 
 echo 'Removing the test module'
 run_with_expected_output dkms remove --all -m dkms_test -v 1.0 << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
@@ -3112,7 +3081,6 @@ EOF
 echo 'Removing all modules'
 echo ' Removing the test module'
 run_with_expected_output dkms remove dkms_test/1.0 -k "${KERNEL_VER}" << EOF
-
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}

--- a/run_test.sh
+++ b/run_test.sh
@@ -1494,7 +1494,6 @@ EOF
 echo 'Adding test module with pre/post scripts'
 run_with_expected_output dkms add test/dkms_scripts_test-1.0 << EOF
 Creating symlink /var/lib/dkms/dkms_scripts_test/1.0/source -> /usr/src/dkms_scripts_test-1.0
-
 Running the post_add script:
 EOF
 check_module_source_tree_created /usr/src/dkms_scripts_test-1.0
@@ -1507,18 +1506,14 @@ set_signing_message "dkms_scripts_test" "1.0"
 SIGNING_MESSAGE_scripts="$SIGNING_MESSAGE"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Running the pre_build script:
 
 Cleaning build area... done.
 Building module(s)... done.
-${SIGNING_MESSAGE_scripts}
-Running the post_build script:
+${SIGNING_MESSAGE_scripts}Running the post_build script:
 Cleaning build area... done.
-
 Running the pre_install script:
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
-
 Running the post_install script:
 Running depmod... done.
 EOF
@@ -1531,7 +1526,6 @@ run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_scripts_test -v
 Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
-
 Running the post_remove script:
 Running depmod... done.
 EOF
@@ -1542,7 +1536,6 @@ EOF
 echo 'Adding noisy test module'
 run_with_expected_output dkms add test/dkms_noisy_test-1.0 << EOF
 Creating symlink /var/lib/dkms/dkms_noisy_test/1.0/source -> /usr/src/dkms_noisy_test-1.0
-
 Running the post_add script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh post_add
 post_add: line 1
@@ -1569,7 +1562,6 @@ Hunk #1 succeeded at 3 (offset 2 lines).
 patching file dkms_noisy_test.c
 Hunk #1 succeeded at 18 (offset 2 lines).
  done.
-
 Running the pre_build script:
 /var/lib/dkms/dkms_noisy_test/1.0/build/script.sh pre_build
 pre_build: line 1
@@ -1580,8 +1572,7 @@ pre_build: line 5
 
 Cleaning build area... done.
 Building module(s)... done.
-${SIGNING_MESSAGE_noisy}
-Running the post_build script:
+${SIGNING_MESSAGE_noisy}Running the post_build script:
 /var/lib/dkms/dkms_noisy_test/1.0/build/script.sh post_build
 post_build: line 1
 post_build: line 2/stderr
@@ -1589,7 +1580,6 @@ post_build: line 3
 post_build: line 4/stderr
 post_build: line 5
 Cleaning build area... done.
-
 Running the pre_install script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh pre_install
 pre_install: line 1
@@ -1598,7 +1588,6 @@ pre_install: line 3
 pre_install: line 4/stderr
 pre_install: line 5
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noisy_test.ko${mod_compression_ext}
-
 Running the post_install script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh post_install
 post_install: line 1
@@ -1617,7 +1606,6 @@ run_with_expected_output dkms unbuild -k "${KERNEL_VER}" -m dkms_noisy_test -v 1
 Module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noisy_test.ko${mod_compression_ext}
-
 Running the post_remove script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh post_remove
 post_remove: line 1
@@ -1643,7 +1631,6 @@ Hunk #1 succeeded at 3 (offset 2 lines).
 patching file dkms_noisy_test.c
 Hunk #1 succeeded at 18 (offset 2 lines).
  done.
-
 Running the pre_build script:
 /var/lib/dkms/dkms_noisy_test/1.0/build/script.sh pre_build
 pre_build: line 1
@@ -1654,8 +1641,7 @@ pre_build: line 5
 
 Cleaning build area... done.
 Building module(s)... done.
-${SIGNING_MESSAGE_noisy}
-Running the post_build script:
+${SIGNING_MESSAGE_noisy}Running the post_build script:
 /var/lib/dkms/dkms_noisy_test/1.0/build/script.sh post_build
 post_build: line 1
 post_build: line 2/stderr
@@ -1663,7 +1649,6 @@ post_build: line 3
 post_build: line 4/stderr
 post_build: line 5
 Cleaning build area... done.
-
 Running the pre_install script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh pre_install
 pre_install: line 1
@@ -1672,7 +1657,6 @@ pre_install: line 3
 pre_install: line 4/stderr
 pre_install: line 5
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noisy_test.ko${mod_compression_ext}
-
 Running the post_install script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh post_install
 post_install: line 1
@@ -1699,18 +1683,14 @@ Running depmod... done.
 
 Autoinstall of module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Running the pre_build script:
 
 Cleaning build area... done.
 Building module(s)... done.
-${SIGNING_MESSAGE_scripts}
-Running the post_build script:
+${SIGNING_MESSAGE_scripts}Running the post_build script:
 Cleaning build area... done.
-
 Running the pre_install script:
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
-
 Running the post_install script:
 Running depmod... done.
 
@@ -1745,7 +1725,6 @@ dkms: removing module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARC
 Module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noisy_test.ko${mod_compression_ext}
-
 Running the post_remove script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh post_remove
 post_remove: line 1
@@ -1763,7 +1742,6 @@ dkms: removing module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_A
 Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
-
 Running the post_remove script:
 
 Running depmod... done.

--- a/run_test.sh
+++ b/run_test.sh
@@ -551,8 +551,8 @@ dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
 EOF
 
 if (( NO_SIGNING_TOOL == 0 )); then
-    echo ' Extracting serial number from the certificate'
-    MODULE_SERIAL="$(cert_serial /tmp/dkms_test_certificate)"
+    echo ' Extracting serial number (aka sig_key in modinfo) from the certificate'
+    CERT_SERIAL="$(cert_serial /tmp/dkms_test_certificate)"
 fi
 
 echo 'Installing the test module'
@@ -608,11 +608,12 @@ if (( NO_SIGNING_TOOL == 0 )); then
     elif [[ "${SIG_HASH}" == "unknown" ]]; then
         echo '  Current kmod reports unknown hash algorithm. Skipping...'
     elif [[ ! "${SIG_KEY}" ]]; then
-        echo >&2 "Error: module was not signed"
+        # kmod may not be linked with openssl and thus can't extract the key from module
+        echo >&2 "Error: module was not signed, or key is unknown"
         exit 1
     else
         run_with_expected_output sh -c "echo '${SIG_KEY}'" << EOF
-${MODULE_SERIAL}
+${CERT_SERIAL}
 EOF
     fi
 fi
@@ -724,11 +725,11 @@ if (( NO_SIGNING_TOOL == 0 )); then
         echo '  Current kmod reports unknown hash algorithm. Skipping...'
     elif [[ ! "${SIG_KEY}" ]]; then
         # kmod may not be linked with openssl and thus can't extract the key from module
-        echo >&2 "Error: modules was not signed, or key is unknown"
+        echo >&2 "Error: module was not signed, or key is unknown"
         exit 1
     else
         run_with_expected_output sh -c "echo '${SIG_KEY}'" << EOF
-${MODULE_SERIAL}
+${CERT_SERIAL}
 EOF
     fi
 fi

--- a/run_test.sh
+++ b/run_test.sh
@@ -430,6 +430,13 @@ run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
 EOF
 
+echo 'Building the test module for a kernel without headers installed (expected error)'
+run_with_expected_error 21 dkms build -k "${KERNEL_VER}-noheaders" -m dkms_test -v 1.0 << EOF
+
+Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
+Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
+EOF
+
 echo 'Building the test module for more than one kernel version (same version twice for this test)'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 Module dkms_test/1.0 already built for kernel ${KERNEL_VER} (${KERNEL_ARCH}), skip. You may override by specifying --force.

--- a/run_test.sh
+++ b/run_test.sh
@@ -352,8 +352,7 @@ if [ "${sign_file}" = "/usr/bin/kmodsign" ]; then
 fi
 
 if (( NO_SIGNING_TOOL == 0 )); then
-    SIGNING_PROLOGUE="
-${SIGNING_PROLOGUE_command}
+    SIGNING_PROLOGUE="${SIGNING_PROLOGUE_command}
 ${SIGNING_PROLOGUE_key}
 ${SIGNING_PROLOGUE_cert}
 "
@@ -415,6 +414,7 @@ echo 'Building the test module'
 set_signing_message "dkms_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -442,8 +442,7 @@ EOF
 
 if (( NO_SIGNING_TOOL == 0 )); then
     SIGNING_PROLOGUE_="${SIGNING_PROLOGUE}"
-    SIGNING_PROLOGUE="
-${SIGNING_PROLOGUE_command}
+    SIGNING_PROLOGUE="${SIGNING_PROLOGUE_command}
 Signing key: /tmp/dkms_test_private_key
 Public certificate (MOK): /tmp/dkms_test_certificate
 "
@@ -451,9 +450,9 @@ Public certificate (MOK): /tmp/dkms_test_certificate
     echo 'Building the test module with bad sign_file path in framework file'
     cp test/framework/bad_sign_file_path.conf /etc/dkms/framework.conf.d/dkms_test_framework.conf
     run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
-
 Sign command: /no/such/file
 Binary /no/such/file not found, modules won't be signed
+
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -463,11 +462,11 @@ EOF
     echo ' Building the test module with bad mok_signing_key path in framework file'
     cp test/framework/bad_key_file_path.conf /etc/dkms/framework.conf.d/dkms_test_framework.conf
     run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
-
 ${SIGNING_PROLOGUE_command}
 Signing key: /no/such/path.key
 Public certificate (MOK): /var/lib/dkms/mok.pub
 Key file /no/such/path.key not found and can't be generated, modules won't be signed
+
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -477,11 +476,11 @@ EOF
     echo ' Building the test module with bad mok_certificate path in framework file'
     cp test/framework/bad_cert_file_path.conf /etc/dkms/framework.conf.d/dkms_test_framework.conf
     run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
-
 ${SIGNING_PROLOGUE_command}
 Signing key: /tmp/dkms_test_private_key
 Public certificate (MOK): /no/such/path.crt
 Certificate file /no/such/path.crt not found and can't be generated, modules won't be signed
+
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -493,10 +492,10 @@ EOF
     mkdir "/tmp/dkms_test_dir_${KERNEL_VER}/"
     cp test/framework/variables_in_path.conf /etc/dkms/framework.conf.d/dkms_test_framework.conf
     run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
-
 Sign command: /lib/modules/${KERNEL_VER}/build/scripts/sign-file
 Signing key: /tmp/dkms_test_dir_${KERNEL_VER}/key
 Public certificate (MOK): /tmp/dkms_test_dir_${KERNEL_VER}/cert
+
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -523,6 +522,7 @@ EOF
         echo "CONFIG_MODULE_SIG_HASH=\"${ALTER_HASH}\"" > /tmp/dkms_test_kconfig
         run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --config /tmp/dkms_test_kconfig --force << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -541,6 +541,7 @@ cp test/framework/temp_key_cert.conf /etc/dkms/framework.conf.d/dkms_test_framew
 echo 'Building the test module again by force'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -688,7 +689,8 @@ EOF
 
 echo 'Installing the test module by version (combining add, build, install)'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
-${SIGNING_PROLOGUE}Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
+${SIGNING_PROLOGUE}
+Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -752,7 +754,8 @@ remove_module_source_tree /usr/src/dkms_test-1.0
 
 echo 'Building the test module by config file (combining add, build)'
 run_with_expected_output dkms build -k "${KERNEL_VER}" test/dkms_test-1.0/dkms.conf << EOF
-${SIGNING_PROLOGUE}Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
+${SIGNING_PROLOGUE}
+Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -799,6 +802,7 @@ echo "Running dkms autoinstall"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -863,6 +867,7 @@ EOF
 echo 'Building the test module'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -894,6 +899,7 @@ echo "Running dkms kernel_postinst"
 run_with_expected_output dkms kernel_postinst -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -960,6 +966,7 @@ echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -990,6 +997,7 @@ echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
@@ -1040,6 +1048,7 @@ echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1048,6 +1057,7 @@ Running depmod... done.
 
 Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
@@ -1118,6 +1128,7 @@ EOF
 echo 'Building the test module with unsatisfied dependencies (expected error)'
 run_with_expected_error 13 dkms build -k "${KERNEL_VER}" -m dkms_dependencies_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Error! Aborting build of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}) due to missing BUILD_DEPENDS: dkms_test.
 You may override by specifying --force.
 EOF
@@ -1129,7 +1140,8 @@ EOF
 
 echo 'Building the test module with unsatisfied dependencies by force'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_dependencies_test -v 1.0 --force << EOF
-${SIGNING_PROLOGUE}Warning: Trying to build module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}) despite of missing BUILD_DEPENDS: dkms_test.
+${SIGNING_PROLOGUE}
+Warning: Trying to build module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}) despite of missing BUILD_DEPENDS: dkms_test.
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -1225,6 +1237,7 @@ EOF
 echo 'Building the test module with circular dependencies (expected error)'
 run_with_expected_error 13 dkms build -k "${KERNEL_VER}" -m dkms_circular_dependencies_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Error! Aborting build of module dkms_circular_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}) due to missing BUILD_DEPENDS: dkms_circular_dependencies_test.
 You may override by specifying --force.
 EOF
@@ -1234,7 +1247,8 @@ EOF
 
 echo 'Building the test module with circular dependencies by force'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_circular_dependencies_test -v 1.0 --force << EOF
-${SIGNING_PROLOGUE}Warning: Trying to build module dkms_circular_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}) despite of missing BUILD_DEPENDS: dkms_circular_dependencies_test.
+${SIGNING_PROLOGUE}
+Warning: Trying to build module dkms_circular_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}) despite of missing BUILD_DEPENDS: dkms_circular_dependencies_test.
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -1291,6 +1305,7 @@ EOF
 set_signing_message "dkms_test" "1.0"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1313,6 +1328,7 @@ EOF
 set_signing_message "dkms_replace_test" "2.0" "dkms_test"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_replace_test -v 2.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1358,6 +1374,7 @@ echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_replace_test/2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1445,7 +1462,8 @@ echo 'Building and installing the test module with patches'
 set_signing_message "dkms_patches_test" "1.0"
 SIGNING_MESSAGE_patches="$SIGNING_MESSAGE"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_patches_test -v 1.0 << EOF
-${SIGNING_PROLOGUE}applying patch patch1.patch...patching file Makefile
+${SIGNING_PROLOGUE}
+applying patch patch1.patch...patching file Makefile
 patching file dkms_patches_test.c
  done.
 applying patch subdir/patch2.patch...patching file Makefile
@@ -1489,6 +1507,7 @@ set_signing_message "dkms_scripts_test" "1.0"
 SIGNING_MESSAGE_scripts="$SIGNING_MESSAGE"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Running the pre_build script:
 
 Cleaning build area... done.
@@ -1541,7 +1560,8 @@ echo 'Building and installing the noisy test module'
 set_signing_message "dkms_noisy_test" "1.0"
 SIGNING_MESSAGE_noisy="$SIGNING_MESSAGE"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_noisy_test -v 1.0 << EOF
-${SIGNING_PROLOGUE}applying patch patch2.patch...patching file Makefile
+${SIGNING_PROLOGUE}
+applying patch patch2.patch...patching file Makefile
 patching file dkms_noisy_test.c
  done.
 applying patch patch1.patch...patching file Makefile
@@ -1614,7 +1634,8 @@ EOF
 echo "Running dkms autoinstall with multiple modules"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}applying patch patch2.patch...patching file Makefile
+${SIGNING_PROLOGUE}
+applying patch patch2.patch...patching file Makefile
 patching file dkms_noisy_test.c
  done.
 applying patch patch1.patch...patching file Makefile
@@ -1662,7 +1683,8 @@ post_install: line 5
 Running depmod... done.
 
 Autoinstall of module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}applying patch patch1.patch...patching file Makefile
+${SIGNING_PROLOGUE}
+applying patch patch1.patch...patching file Makefile
 patching file dkms_patches_test.c
  done.
 applying patch subdir/patch2.patch...patching file Makefile
@@ -1677,6 +1699,7 @@ Running depmod... done.
 
 Autoinstall of module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Running the pre_build script:
 
 Cleaning build area... done.
@@ -1827,6 +1850,7 @@ echo 'Building the noautoinstall test module'
 set_signing_message "dkms_noautoinstall_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_noautoinstall_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1946,7 +1970,8 @@ EOF
 
 echo 'Testing add/build/install of a test module building zero kernel modules'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_conf_test -v 1.0 << EOF
-${SIGNING_PROLOGUE}dkms.conf: Warning! Zero modules specified.
+${SIGNING_PROLOGUE}
+dkms.conf: Warning! Zero modules specified.
 Creating symlink /var/lib/dkms/dkms_conf_test/1.0/source -> /usr/src/dkms_conf_test-1.0
 
 Cleaning build area... done.
@@ -1983,6 +2008,7 @@ EOF
 echo 'Building test module without source (expected error)'
 run_with_expected_error 8 dkms build -k "${KERNEL_VER}" -m dkms_conf_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Error! The directory /var/lib/dkms/dkms_conf_test/1.0/source does not appear to have module source located within it.
 Build halted.
 EOF
@@ -2009,6 +2035,7 @@ EOF
 echo ' Building test module with missing patch (expected error)'
 run_with_expected_error 5 dkms build -k "${KERNEL_VER}" -m dkms_conf_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Error! Patch missing.patch as specified in dkms.conf cannot be
 found in /var/lib/dkms/dkms_conf_test/1.0/build/patches/.
 EOF
@@ -2035,6 +2062,7 @@ EOF
 echo ' Building test module with bad patch path (expected error)'
 run_with_expected_error 5 dkms build -k "${KERNEL_VER}" -m dkms_conf_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Error! Patch ../badpath.patch as specified in dkms.conf contains '..' path component.
 EOF
 run_status_with_expected_output 'dkms_conf_test' << EOF
@@ -2060,6 +2088,7 @@ EOF
 echo ' Building test module with bad patch path (expected error)'
 run_with_expected_error 5 dkms build -k "${KERNEL_VER}" -m dkms_conf_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Error! Patch subdir/../badpath.patch as specified in dkms.conf contains '..' path component.
 EOF
 run_status_with_expected_output 'dkms_conf_test' << EOF
@@ -2094,6 +2123,7 @@ BUILD_MESSAGES="${SIGNING_MESSAGE}${SIGNING_MESSAGE}"
 fi
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_duplicate_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area...(bad exit status: 1)
 Failed command:
 echo oops >&2 && false
@@ -2137,6 +2167,7 @@ echo ' Building and installing the test module'
 set_signing_message "dkms_crlf_test" "1.0" "dkms_dos_test"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_crlf_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2189,6 +2220,7 @@ echo 'Building the multiver test modules'
 set_signing_message "dkms_multiver_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_multiver_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2200,6 +2232,7 @@ EOF
 set_signing_message "dkms_multiver_test" "2.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_multiver_test -v 2.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2326,6 +2359,7 @@ echo 'Building the nover/emptyver test modules'
 set_signing_message "dkms_nover_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_nover_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2336,6 +2370,7 @@ EOF
 set_signing_message "dkms_emptyver_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_emptyver_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2435,6 +2470,7 @@ echo 'Installing the nover update test 1.0 modules'
 set_signing_message "dkms_nover_update_test" "1.0"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_nover_update_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2459,6 +2495,7 @@ echo 'Installing the nover update test 2.0 modules'
 set_signing_message "dkms_nover_update_test" "2.0"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_nover_update_test -v 2.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2485,6 +2522,7 @@ echo 'Building the nover update test 3.0 modules'
 set_signing_message "dkms_nover_update_test" "3.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_nover_update_test -v 3.0 << EOF
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2555,6 +2593,7 @@ echo 'Running autoinstall with failing test module (expected error)'
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
@@ -2578,6 +2617,7 @@ echo 'Running autoinstall with failing test module and test module with dependen
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
@@ -2642,7 +2682,8 @@ EOF
 # Should this really fail?
 echo '(Not) building the build-exclusive test module'
 run_with_expected_error 77 dkms build -k "${KERNEL_VER}" -m dkms_build_exclusive_test -v 1.0 << EOF
-${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+${SIGNING_PROLOGUE}
+Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
@@ -2654,7 +2695,8 @@ EOF
 echo "Running dkms autoinstall (1 x skip)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+${SIGNING_PROLOGUE}
+Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
@@ -2677,13 +2719,15 @@ EOF
 echo "Running dkms autoinstall (1 x skip, 1 x pass)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+${SIGNING_PROLOGUE}
+Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2720,13 +2764,15 @@ check_module_source_tree_created /usr/src/dkms_failing_test-1.0
 echo "Running dkms autoinstall (1 x skip, 1 x fail, 1 x pass) (expected error)"
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+${SIGNING_PROLOGUE}
+Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
@@ -2737,6 +2783,7 @@ Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2787,13 +2834,15 @@ EOF
 echo "Running dkms autoinstall (2 x skip, with dependency)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+${SIGNING_PROLOGUE}
+Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_build_exclusive_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_dependencies_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+${SIGNING_PROLOGUE}
+Warning: The /var/lib/dkms/dkms_build_exclusive_dependencies_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_dependencies_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
@@ -3028,7 +3077,8 @@ rm -rf /var/lib/dkms/dkms_test/
 echo 'Adding and building the test module by directory'
 set_signing_message "dkms_test" "1.0"
 run_with_expected_output dkms build test/dkms_test-1.0 -k "${KERNEL_VER}" << EOF
-${SIGNING_PROLOGUE}Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
+${SIGNING_PROLOGUE}
+Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -3038,7 +3088,8 @@ EOF
 echo 'Adding and building the multiver test module 1.0 by directory'
 set_signing_message "dkms_multiver_test" "1.0"
 run_with_expected_output dkms build test/dkms_multiver_test/1.0 -k "${KERNEL_VER}" << EOF
-${SIGNING_PROLOGUE}Creating symlink /var/lib/dkms/dkms_multiver_test/1.0/source -> /usr/src/dkms_multiver_test-1.0
+${SIGNING_PROLOGUE}
+Creating symlink /var/lib/dkms/dkms_multiver_test/1.0/source -> /usr/src/dkms_multiver_test-1.0
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -3051,7 +3102,8 @@ rm /var/lib/dkms/dkms_multiver_test/1.0/source
 echo 'Adding and building the multiver test module 2.0 by directory'
 set_signing_message "dkms_multiver_test" "2.0"
 run_with_expected_output dkms build test/dkms_multiver_test/2.0 -k "${KERNEL_VER}" << EOF
-${SIGNING_PROLOGUE}Creating symlink /var/lib/dkms/dkms_multiver_test/2.0/source -> /usr/src/dkms_multiver_test-2.0
+${SIGNING_PROLOGUE}
+Creating symlink /var/lib/dkms/dkms_multiver_test/2.0/source -> /usr/src/dkms_multiver_test-2.0
 
 Cleaning build area... done.
 Building module(s)... done.

--- a/run_test.sh
+++ b/run_test.sh
@@ -556,7 +556,6 @@ fi
 
 echo 'Installing the test module'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -696,7 +695,6 @@ ${SIGNING_PROLOGUE}Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/s
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -770,7 +768,6 @@ EOF
 echo "Running dkms autoinstall (module already built)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -809,7 +806,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -906,7 +902,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -974,7 +969,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -1005,7 +999,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -1058,7 +1051,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -1067,7 +1059,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -1162,7 +1153,6 @@ EOF
 
 echo 'Installing the test module with unsatisfied dependencies'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_dependencies_test -v 1.0 << EOF
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -1267,7 +1257,6 @@ EOF
 
 echo 'Installing the test module with circular dependencies'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_circular_dependencies_test -v 1.0 << EOF
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_circular_dependencies_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -1317,7 +1306,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -1340,7 +1328,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Found pre-existing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}, archiving for uninstallation
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
@@ -1387,7 +1374,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Found pre-existing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}, archiving for uninstallation
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
@@ -1484,7 +1470,6 @@ patching file dkms_patches_test.c
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_patches}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -1527,7 +1512,6 @@ Building module(s)... done.
 ${SIGNING_MESSAGE_scripts}
 Running the post_build script:
 Cleaning build area... done.
-
 
 Running the pre_install script:
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
@@ -1603,7 +1587,6 @@ post_build: line 4/stderr
 post_build: line 5
 Cleaning build area... done.
 
-
 Running the pre_install script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh pre_install
 pre_install: line 1
@@ -1678,7 +1661,6 @@ post_build: line 4/stderr
 post_build: line 5
 Cleaning build area... done.
 
-
 Running the pre_install script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh pre_install
 pre_install: line 1
@@ -1708,7 +1690,6 @@ patching file dkms_patches_test.c
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_patches}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -1721,7 +1702,6 @@ Building module(s)... done.
 ${SIGNING_MESSAGE_scripts}
 Running the post_build script:
 Cleaning build area... done.
-
 
 Running the pre_install script:
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
@@ -1878,7 +1858,6 @@ EOF
 
 echo 'Installing the noautoinstall test module'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_noautoinstall_test -v 1.0 << EOF
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_noautoinstall_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -1995,7 +1974,6 @@ Creating symlink /var/lib/dkms/dkms_conf_test/1.0/source -> /usr/src/dkms_conf_t
 Cleaning build area... done.
 Building module(s)... done.
 Cleaning build area... done.
-
 Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_conf_test' << EOF
@@ -2146,7 +2124,6 @@ Building module(s)... done.
 ${BUILD_MESSAGES}Cleaning build area...(bad exit status: 1)
 Failed command:
 echo oops >&2 && false
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_duplicate_test.ko${mod_compression_ext}
 Module /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_duplicate_test.ko${mod_compression_ext} already installed (unversioned module), override by specifying --force
 Running depmod... done.
@@ -2187,7 +2164,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dos_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -2260,7 +2236,6 @@ EOF
 
 echo 'Installing the multiver test modules'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_multiver_test -v 1.0 << EOF
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_multiver_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -2269,7 +2244,6 @@ dkms_multiver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 dkms_multiver_test/2.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
 EOF
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_multiver_test -v 2.0 << EOF
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_multiver_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -2278,7 +2252,6 @@ dkms_multiver_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
 dkms_multiver_test/2.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 run_with_expected_error 6 dkms install -k "${KERNEL_VER}" -m dkms_multiver_test -v 1.0 << EOF
-
 
 Error! Module version 1.0 for dkms_multiver_test.ko${mod_compression_ext}
 is not newer than what is already found in kernel ${KERNEL_VER} (2.0).
@@ -2399,7 +2372,6 @@ EOF
 
 echo 'Installing the nover/emptyver test modules'
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_nover_test -v 1.0 << EOF
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -2407,7 +2379,6 @@ run_status_with_expected_output 'dkms_nover_test' << EOF
 dkms_nover_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_emptyver_test -v 1.0 << EOF
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_emptyver_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -2495,7 +2466,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_update_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -2520,7 +2490,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_update_test.ko${mod_compression_ext}
 Running depmod... done.
 EOF
@@ -2563,7 +2532,6 @@ else
     echo ' Installing the nover update test 3.0 modules (expected error)'
     set_signing_message "dkms_nover_update_test" "3.0"
     run_with_expected_error 6 dkms install -k "${KERNEL_VER}" -m dkms_nover_update_test -v 3.0 << EOF
-
 Module /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_nover_update_test.ko${mod_compression_ext} already installed (unversioned module), override by specifying --force
 
 Error! Installation aborted.
@@ -2748,7 +2716,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -2803,7 +2770,6 @@ ${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 
@@ -3129,7 +3095,6 @@ run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Error! dkms_multiver_test/1.0 is broken! Missing the source directory or the symbolic link pointing to it.
 Manual intervention is required!
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -414,7 +414,6 @@ echo 'Building the test module'
 set_signing_message "dkms_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -453,7 +452,6 @@ Public certificate (MOK): /tmp/dkms_test_certificate
 Sign command: /no/such/file
 Binary /no/such/file not found, modules won't be signed
 
-
 Cleaning build area... done.
 Building module(s)... done.
 Cleaning build area... done.
@@ -466,7 +464,6 @@ ${SIGNING_PROLOGUE_command}
 Signing key: /no/such/path.key
 Public certificate (MOK): /var/lib/dkms/mok.pub
 Key file /no/such/path.key not found and can't be generated, modules won't be signed
-
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -481,7 +478,6 @@ Signing key: /tmp/dkms_test_private_key
 Public certificate (MOK): /no/such/path.crt
 Certificate file /no/such/path.crt not found and can't be generated, modules won't be signed
 
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -495,7 +491,6 @@ EOF
 Sign command: /lib/modules/${KERNEL_VER}/build/scripts/sign-file
 Signing key: /tmp/dkms_test_dir_${KERNEL_VER}/key
 Public certificate (MOK): /tmp/dkms_test_dir_${KERNEL_VER}/cert
-
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -522,7 +517,6 @@ EOF
         echo "CONFIG_MODULE_SIG_HASH=\"${ALTER_HASH}\"" > /tmp/dkms_test_kconfig
         run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --config /tmp/dkms_test_kconfig --force << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -541,7 +535,6 @@ cp test/framework/temp_key_cert.conf /etc/dkms/framework.conf.d/dkms_test_framew
 echo 'Building the test module again by force'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 --force << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -692,7 +685,6 @@ run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << 
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -758,7 +750,6 @@ run_with_expected_output dkms build -k "${KERNEL_VER}" test/dkms_test-1.0/dkms.c
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -804,7 +795,6 @@ echo "Running dkms autoinstall"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -869,7 +859,6 @@ EOF
 echo 'Building the test module'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -901,7 +890,6 @@ echo "Running dkms kernel_postinst"
 run_with_expected_output dkms kernel_postinst -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -968,7 +956,6 @@ echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -999,7 +986,6 @@ echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
@@ -1050,7 +1036,6 @@ echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1059,7 +1044,6 @@ Running depmod... done.
 
 Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
@@ -1144,7 +1128,6 @@ echo 'Building the test module with unsatisfied dependencies by force'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_dependencies_test -v 1.0 --force << EOF
 ${SIGNING_PROLOGUE}
 Warning: Trying to build module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}) despite of missing BUILD_DEPENDS: dkms_test.
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
@@ -1251,7 +1234,6 @@ echo 'Building the test module with circular dependencies by force'
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_circular_dependencies_test -v 1.0 --force << EOF
 ${SIGNING_PROLOGUE}
 Warning: Trying to build module dkms_circular_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}) despite of missing BUILD_DEPENDS: dkms_circular_dependencies_test.
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1307,7 +1289,6 @@ EOF
 set_signing_message "dkms_test" "1.0"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1330,7 +1311,6 @@ EOF
 set_signing_message "dkms_replace_test" "2.0" "dkms_test"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_replace_test -v 2.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1376,7 +1356,6 @@ echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_replace_test/2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1471,7 +1450,6 @@ patching file dkms_patches_test.c
 applying patch subdir/patch2.patch...patching file Makefile
 patching file dkms_patches_test.c
  done.
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_patches}Cleaning build area... done.
@@ -1509,7 +1487,6 @@ SIGNING_MESSAGE_scripts="$SIGNING_MESSAGE"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_scripts_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
 Running the pre_build script:
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_scripts}Running the post_build script:
@@ -1571,7 +1548,6 @@ pre_build: line 2/stderr
 pre_build: line 3
 pre_build: line 4/stderr
 pre_build: line 5
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_noisy}Running the post_build script:
@@ -1640,7 +1616,6 @@ pre_build: line 2/stderr
 pre_build: line 3
 pre_build: line 4/stderr
 pre_build: line 5
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_noisy}Running the post_build script:
@@ -1676,7 +1651,6 @@ patching file dkms_patches_test.c
 applying patch subdir/patch2.patch...patching file Makefile
 patching file dkms_patches_test.c
  done.
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_patches}Cleaning build area... done.
@@ -1686,7 +1660,6 @@ Running depmod... done.
 Autoinstall of module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Running the pre_build script:
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_scripts}Running the post_build script:
@@ -1830,7 +1803,6 @@ echo 'Building the noautoinstall test module'
 set_signing_message "dkms_noautoinstall_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_noautoinstall_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1953,7 +1925,6 @@ run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_conf_test -v 1.
 ${SIGNING_PROLOGUE}
 dkms.conf: Warning! Zero modules specified.
 Creating symlink /var/lib/dkms/dkms_conf_test/1.0/source -> /usr/src/dkms_conf_test-1.0
-
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -2104,7 +2075,6 @@ BUILD_MESSAGES="${SIGNING_MESSAGE}${SIGNING_MESSAGE}"
 fi
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_duplicate_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area...(bad exit status: 1)
 Failed command:
 echo oops >&2 && false
@@ -2148,7 +2118,6 @@ echo ' Building and installing the test module'
 set_signing_message "dkms_crlf_test" "1.0" "dkms_dos_test"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_crlf_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2201,7 +2170,6 @@ echo 'Building the multiver test modules'
 set_signing_message "dkms_multiver_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_multiver_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2213,7 +2181,6 @@ EOF
 set_signing_message "dkms_multiver_test" "2.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_multiver_test -v 2.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2340,7 +2307,6 @@ echo 'Building the nover/emptyver test modules'
 set_signing_message "dkms_nover_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_nover_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2351,7 +2317,6 @@ EOF
 set_signing_message "dkms_emptyver_test" "1.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_emptyver_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2451,7 +2416,6 @@ echo 'Installing the nover update test 1.0 modules'
 set_signing_message "dkms_nover_update_test" "1.0"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_nover_update_test -v 1.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2476,7 +2440,6 @@ echo 'Installing the nover update test 2.0 modules'
 set_signing_message "dkms_nover_update_test" "2.0"
 run_with_expected_output dkms install -k "${KERNEL_VER}" -m dkms_nover_update_test -v 2.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2503,7 +2466,6 @@ echo 'Building the nover update test 3.0 modules'
 set_signing_message "dkms_nover_update_test" "3.0"
 run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_nover_update_test -v 3.0 << EOF
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2574,7 +2536,6 @@ echo 'Running autoinstall with failing test module (expected error)'
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
@@ -2598,7 +2559,6 @@ echo 'Running autoinstall with failing test module and test module with dependen
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
@@ -2708,7 +2668,6 @@ This indicates that it should not be built.
 
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2753,7 +2712,6 @@ This indicates that it should not be built.
 
 Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
@@ -2764,7 +2722,6 @@ Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -3061,7 +3018,6 @@ run_with_expected_output dkms build test/dkms_test-1.0 -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_test/1.0/source -> /usr/src/dkms_test-1.0
 
-
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -3072,7 +3028,6 @@ set_signing_message "dkms_multiver_test" "1.0"
 run_with_expected_output dkms build test/dkms_multiver_test/1.0 -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_multiver_test/1.0/source -> /usr/src/dkms_multiver_test-1.0
-
 
 Cleaning build area... done.
 Building module(s)... done.
@@ -3087,7 +3042,6 @@ set_signing_message "dkms_multiver_test" "2.0"
 run_with_expected_output dkms build test/dkms_multiver_test/2.0 -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Creating symlink /var/lib/dkms/dkms_multiver_test/2.0/source -> /usr/src/dkms_multiver_test-2.0
-
 
 Cleaning build area... done.
 Building module(s)... done.

--- a/run_test.sh
+++ b/run_test.sh
@@ -1547,7 +1547,9 @@ pre_build: line 2/stderr
 pre_build: line 3
 pre_build: line 4/stderr
 pre_build: line 5
-Cleaning build area... done.
+Cleaning build area...(bad exit status: 2)
+Failed command:
+make clean
 Building module(s)... done.
 ${SIGNING_MESSAGE_noisy}Running the post_build script:
 /var/lib/dkms/dkms_noisy_test/1.0/build/script.sh post_build
@@ -1556,7 +1558,9 @@ post_build: line 2/stderr
 post_build: line 3
 post_build: line 4/stderr
 post_build: line 5
-Cleaning build area... done.
+Cleaning build area...(bad exit status: 2)
+Failed command:
+make clean
 Running the pre_install script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh pre_install
 pre_install: line 1
@@ -1665,7 +1669,9 @@ pre_build: line 2/stderr
 pre_build: line 3
 pre_build: line 4/stderr
 pre_build: line 5
-Cleaning build area... done.
+Cleaning build area...(bad exit status: 2)
+Failed command:
+make clean
 Building module(s)... done.
 ${SIGNING_MESSAGE_noisy}Running the post_build script:
 /var/lib/dkms/dkms_noisy_test/1.0/build/script.sh post_build
@@ -1674,7 +1680,9 @@ post_build: line 2/stderr
 post_build: line 3
 post_build: line 4/stderr
 post_build: line 5
-Cleaning build area... done.
+Cleaning build area...(bad exit status: 2)
+Failed command:
+make clean
 Running the pre_install script:
 /var/lib/dkms/dkms_noisy_test/1.0/source/script.sh pre_install
 pre_install: line 1

--- a/run_test.sh
+++ b/run_test.sh
@@ -799,8 +799,8 @@ rm -f /etc/dkms/no-autoinstall
 
 echo "Running dkms autoinstall"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -821,16 +821,10 @@ dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 
 echo "Running dkms autoinstall for a kernel without headers installed (expected error)"
-run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}-noheaders" << EOF
-Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER}-noheaders (${KERNEL_ARCH})
+run_with_expected_error 21 dkms autoinstall -k "${KERNEL_VER}-noheaders" << EOF
 
 Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
 Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
-
-Autoinstall on ${KERNEL_VER}-noheaders failed for module(s) dkms_test(21).
-
-Error! One or more modules failed to install during autoinstall.
-Refer to previous errors for more information.
 EOF
 
 echo 'Running dkms kernel_prerm w/o kernel argument (expected error)'
@@ -894,8 +888,8 @@ EOF
 
 echo "Running dkms kernel_postinst"
 run_with_expected_output dkms kernel_postinst -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -960,8 +954,8 @@ EOF
 
 echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -990,8 +984,8 @@ EOF
 
 echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
@@ -1040,8 +1034,8 @@ EOF
 
 echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1049,7 +1043,6 @@ Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_com
 Running depmod... done.
 
 Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
@@ -1360,8 +1353,8 @@ EOF
 
 echo 'Running dkms autoinstall'
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_replace_test/2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_replace_test/2.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -1605,8 +1598,8 @@ EOF
 
 echo "Running dkms autoinstall with multiple modules"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 applying patch patch2.patch...patching file Makefile
 patching file dkms_noisy_test.c
  done.
@@ -1650,7 +1643,6 @@ post_install: line 5
 Running depmod... done.
 
 Autoinstall of module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}
 applying patch patch1.patch...patching file Makefile
 patching file dkms_patches_test.c
  done.
@@ -1664,7 +1656,6 @@ Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko$
 Running depmod... done.
 
 Autoinstall of module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}
 Running the pre_build script:
 Cleaning build area... done.
 Building module(s)... done.
@@ -2535,8 +2526,8 @@ EOF
 check_module_source_tree_created /usr/src/dkms_failing_test-1.0
 echo 'Running autoinstall with failing test module (expected error)'
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
@@ -2558,8 +2549,8 @@ EOF
 check_module_source_tree_created /usr/src/dkms_failing_dependencies_test-1.0
 echo 'Running autoinstall with failing test module and test module with dependencies on the failing module (expected error)'
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
@@ -2636,8 +2627,8 @@ EOF
 
 echo "Running dkms autoinstall (1 x skip)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
@@ -2660,15 +2651,14 @@ EOF
 
 echo "Running dkms autoinstall (1 x skip, 1 x pass)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2704,15 +2694,14 @@ check_module_source_tree_created /usr/src/dkms_failing_test-1.0
 
 echo "Running dkms autoinstall (1 x skip, 1 x fail, 1 x pass) (expected error)"
 run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)...(bad exit status: 2)
 Failed command:
@@ -2722,7 +2711,6 @@ Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARC
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
 
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}
 Cleaning build area... done.
 Building module(s)... done.
 ${SIGNING_MESSAGE}Cleaning build area... done.
@@ -2772,15 +2760,14 @@ EOF
 
 echo "Running dkms autoinstall (2 x skip, with dependency)"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
-Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_build_exclusive_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
-${SIGNING_PROLOGUE}
 Warning: The /var/lib/dkms/dkms_build_exclusive_dependencies_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_dependencies_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.

--- a/run_test.sh
+++ b/run_test.sh
@@ -1596,6 +1596,15 @@ run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0: added
 EOF
 
+echo 'Adding noautoinstall test module'
+run_with_expected_output dkms add test/dkms_noautoinstall_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_noautoinstall_test/1.0/source -> /usr/src/dkms_noautoinstall_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_noautoinstall_test-1.0
+run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
+dkms_noautoinstall_test/1.0: added
+EOF
+
 echo "Running dkms autoinstall with multiple modules"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
@@ -1677,6 +1686,9 @@ EOF
 run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
+run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
+dkms_noautoinstall_test/1.0: added
+EOF
 
 echo "Running dkms autoinstall again with multiple modules"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
@@ -1689,6 +1701,9 @@ dkms_scripts_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
+EOF
+run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
+dkms_noautoinstall_test/1.0: added
 EOF
 
 echo 'Running dkms kernel_prerm'
@@ -1727,6 +1742,9 @@ EOF
 run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0: added
 EOF
+run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
+dkms_noautoinstall_test/1.0: added
+EOF
 
 echo 'Running dkms kernel_prerm again'
 run_with_expected_output dkms kernel_prerm -k "${KERNEL_VER}" << EOF
@@ -1739,6 +1757,9 @@ dkms_scripts_test/1.0: added
 EOF
 run_status_with_expected_output 'dkms_noisy_test' << EOF
 dkms_noisy_test/1.0: added
+EOF
+run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
+dkms_noautoinstall_test/1.0: added
 EOF
 
 echo 'Removing the test module with patches'
@@ -1771,7 +1792,21 @@ EOF
 run_status_with_expected_output 'dkms_noisy_test' << EOF
 EOF
 
-remove_module_source_tree /usr/src/dkms_patches_test-1.0 /usr/src/dkms_scripts_test-1.0 /usr/src/dkms_noisy_test-1.0
+echo 'Removing the noautoinstall test module'
+run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_noautoinstall_test -v 1.0 << EOF
+Module dkms_noautoinstall_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+Module dkms_noautoinstall_test/1.0 is not built for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+
+Deleting module dkms_noautoinstall_test/1.0 completely from the DKMS tree.
+EOF
+run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
+EOF
+
+remove_module_source_tree \
+        /usr/src/dkms_patches_test-1.0 \
+        /usr/src/dkms_scripts_test-1.0 \
+        /usr/src/dkms_noisy_test-1.0 \
+        /usr/src/dkms_noautoinstall_test-1.0 \
 
 echo 'Checking that the environment is clean again'
 check_no_dkms_test

--- a/run_test.sh
+++ b/run_test.sh
@@ -674,7 +674,6 @@ EOF
 
 echo 'Removing the test module'
 run_with_expected_output dkms remove --all -m dkms_test -v 1.0 << EOF
-
 Deleting module dkms_test/1.0 completely from the DKMS tree.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -1914,7 +1913,6 @@ dkms_conf_test/1.0: added
 EOF
 
 run_with_expected_output dkms remove --all -m dkms_conf_test -v 1.0 << EOF
-
 Deleting module dkms_conf_test/1.0 completely from the DKMS tree.
 EOF
 run_status_with_expected_output 'dkms_conf_test' << EOF
@@ -1969,7 +1967,6 @@ dkms_conf_test/1.0: added
 EOF
 
 run_with_expected_output dkms remove --all -m dkms_conf_test -v 1.0 << EOF
-
 Deleting module dkms_conf_test/1.0 completely from the DKMS tree.
 EOF
 
@@ -1996,7 +1993,6 @@ dkms_conf_test/1.0: added
 EOF
 
 run_with_expected_output dkms remove --all -m dkms_conf_test -v 1.0 << EOF
-
 Deleting module dkms_conf_test/1.0 completely from the DKMS tree.
 EOF
 
@@ -2022,7 +2018,6 @@ dkms_conf_test/1.0: added
 EOF
 
 run_with_expected_output dkms remove --all -m dkms_conf_test -v 1.0 << EOF
-
 Deleting module dkms_conf_test/1.0 completely from the DKMS tree.
 EOF
 
@@ -2048,7 +2043,6 @@ dkms_conf_test/1.0: added
 EOF
 
 run_with_expected_output dkms remove --all -m dkms_conf_test -v 1.0 << EOF
-
 Deleting module dkms_conf_test/1.0 completely from the DKMS tree.
 EOF
 
@@ -2796,7 +2790,6 @@ EOF
 
 echo 'Removing the build-exclusive dependencies test module'
 run_with_expected_output dkms remove --all -m dkms_build_exclusive_dependencies_test -v 1.0 << EOF
-
 Deleting module dkms_build_exclusive_dependencies_test/1.0 completely from the DKMS tree.
 EOF
 run_status_with_expected_output 'dkms_build_exclusive_dependencies_test' << EOF
@@ -2806,7 +2799,6 @@ remove_module_source_tree /usr/src/dkms_build_exclusive_dependencies_test-1.0
 
 echo 'Removing the build-exclusive test module'
 run_with_expected_output dkms remove --all -m dkms_build_exclusive_test -v 1.0 << EOF
-
 Deleting module dkms_build_exclusive_test/1.0 completely from the DKMS tree.
 EOF
 run_status_with_expected_output 'dkms_build_exclusive_test' << EOF

--- a/run_test.sh
+++ b/run_test.sh
@@ -820,7 +820,7 @@ Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER}-noheaders (${KERNEL
 Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
 Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
 
-Autoinstall on ${KERNEL_VER}-noheaders failed for module(s) dkms_test(1).
+Autoinstall on ${KERNEL_VER}-noheaders failed for module(s) dkms_test(21).
 
 Error! One or more modules failed to install during autoinstall.
 Refer to previous errors for more information.

--- a/run_test.sh
+++ b/run_test.sh
@@ -1612,6 +1612,15 @@ run_status_with_expected_output 'dkms_dependencies_test' << EOF
 dkms_dependencies_test/1.0: added
 EOF
 
+echo 'Adding build-exclusive test module'
+run_with_expected_output dkms add test/dkms_build_exclusive_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_build_exclusive_test/1.0/source -> /usr/src/dkms_build_exclusive_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_build_exclusive_test-1.0
+run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
+dkms_build_exclusive_test/1.0: added
+EOF
+
 echo 'Adding noautoinstall test module'
 run_with_expected_output dkms add test/dkms_noautoinstall_test-1.0 << EOF
 Creating symlink /var/lib/dkms/dkms_noautoinstall_test/1.0/source -> /usr/src/dkms_noautoinstall_test-1.0
@@ -1634,6 +1643,12 @@ echo "Running dkms autoinstall with multiple modules"
 set_signing_message "dkms_test" "1.0"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
+Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
+which does not match this kernel/arch/config.
+This indicates that it should not be built.
+
 Autoinstall of module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 applying patch patch2.patch...patching file Makefile
 patching file dkms_noisy_test.c
@@ -1716,6 +1731,7 @@ Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_tes
 Running depmod... done.
 
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_noisy_test dkms_patches_test dkms_scripts_test dkms_test dkms_dependencies_test.
+Autoinstall on ${KERNEL_VER} was skipped for module(s) dkms_build_exclusive_test.
 EOF
 run_status_with_expected_output 'dkms_patches_test' << EOF
 dkms_patches_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
@@ -1728,6 +1744,9 @@ dkms_noisy_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 run_status_with_expected_output 'dkms_dependencies_test' << EOF
 dkms_dependencies_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
+EOF
+run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
+dkms_build_exclusive_test/1.0: added
 EOF
 run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
 dkms_noautoinstall_test/1.0: added
@@ -1738,6 +1757,15 @@ EOF
 
 echo "Running dkms autoinstall again with multiple modules"
 run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
+${SIGNING_PROLOGUE}
+Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
+Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
+which does not match this kernel/arch/config.
+This indicates that it should not be built.
+
+Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_dependencies_test dkms_noisy_test dkms_patches_test dkms_scripts_test dkms_test.
+Autoinstall on ${KERNEL_VER} was skipped for module(s) dkms_build_exclusive_test.
 EOF
 run_status_with_expected_output 'dkms_patches_test' << EOF
 dkms_patches_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
@@ -1750,6 +1778,9 @@ dkms_noisy_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
 EOF
 run_status_with_expected_output 'dkms_dependencies_test' << EOF
 dkms_dependencies_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed
+EOF
+run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
+dkms_build_exclusive_test/1.0: added
 EOF
 run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
 dkms_noautoinstall_test/1.0: added
@@ -1807,6 +1838,9 @@ EOF
 run_status_with_expected_output 'dkms_dependencies_test' << EOF
 dkms_dependencies_test/1.0: added
 EOF
+run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
+dkms_build_exclusive_test/1.0: added
+EOF
 run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
 dkms_noautoinstall_test/1.0: added
 EOF
@@ -1828,6 +1862,9 @@ dkms_noisy_test/1.0: added
 EOF
 run_status_with_expected_output 'dkms_dependencies_test' << EOF
 dkms_dependencies_test/1.0: added
+EOF
+run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
+dkms_build_exclusive_test/1.0: added
 EOF
 run_status_with_expected_output 'dkms_noautoinstall_test' << EOF
 dkms_noautoinstall_test/1.0: added
@@ -1876,6 +1913,16 @@ EOF
 run_status_with_expected_output 'dkms_dependencies_test' << EOF
 EOF
 
+echo 'Removing the build-exclusive test module'
+run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_build_exclusive_test -v 1.0 << EOF
+Module dkms_build_exclusive_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+Module dkms_build_exclusive_test/1.0 is not built for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+
+Deleting module dkms_build_exclusive_test/1.0 completely from the DKMS tree.
+EOF
+run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
+EOF
+
 echo 'Removing the noautoinstall test module'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_noautoinstall_test -v 1.0 << EOF
 Module dkms_noautoinstall_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
@@ -1901,6 +1948,7 @@ remove_module_source_tree \
         /usr/src/dkms_scripts_test-1.0 \
         /usr/src/dkms_noisy_test-1.0 \
         /usr/src/dkms_dependencies_test-1.0 \
+        /usr/src/dkms_build_exclusive_test-1.0 \
         /usr/src/dkms_noautoinstall_test-1.0 \
         /usr/src/dkms_test-1.0
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -773,6 +773,7 @@ Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -811,6 +812,7 @@ ${SIGNING_MESSAGE}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -830,6 +832,7 @@ Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER}-noheaders (${KERNEL
 
 Error! Your kernel headers for kernel ${KERNEL_VER}-noheaders cannot be found at /lib/modules/${KERNEL_VER}-noheaders/build or /lib/modules/${KERNEL_VER}-noheaders/source.
 Please install the linux-headers-${KERNEL_VER}-noheaders package or use the --kernelsourcedir option to tell DKMS where it's located.
+
 Autoinstall on ${KERNEL_VER}-noheaders failed for module(s) dkms_test(1).
 
 Error! One or more modules failed to install during autoinstall.
@@ -852,6 +855,7 @@ dkms: removing module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
 Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -880,6 +884,7 @@ echo 'Running dkms kernel_prerm'
 run_with_expected_output dkms kernel_prerm -k "${KERNEL_VER}" << EOF
 dkms: removing module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Module dkms_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
 dkms_test/1.0: added
@@ -904,6 +909,7 @@ ${SIGNING_MESSAGE}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -971,6 +977,7 @@ ${SIGNING_MESSAGE}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -1001,6 +1008,7 @@ ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test dkms_dependencies_test.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -1017,11 +1025,13 @@ dkms: removing module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KER
 Module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
+
 dkms: removing module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
+
 Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -1051,6 +1061,7 @@ ${SIGNING_MESSAGE}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall of module dkms_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
@@ -1059,6 +1070,7 @@ ${SIGNING_MESSAGE_dependencies}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_dependencies_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test dkms_dependencies_test.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
@@ -1379,6 +1391,7 @@ ${SIGNING_MESSAGE}Cleaning build area... done.
 Found pre-existing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}, archiving for uninstallation
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test dkms_replace_test.
 EOF
 run_status_with_expected_output 'dkms_replace_test' << EOF
@@ -1683,6 +1696,7 @@ post_install: line 3
 post_install: line 4/stderr
 post_install: line 5
 Running depmod... done.
+
 Autoinstall of module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}applying patch patch1.patch...patching file Makefile
 patching file dkms_patches_test.c
@@ -1697,6 +1711,7 @@ ${SIGNING_MESSAGE_patches}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall of module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Running the pre_build script:
@@ -1713,6 +1728,7 @@ Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko$
 
 Running the post_install script:
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_noisy_test dkms_patches_test dkms_scripts_test.
 EOF
 run_status_with_expected_output 'dkms_patches_test' << EOF
@@ -1753,11 +1769,13 @@ post_remove: line 2/stderr
 post_remove: line 3
 post_remove: line 4/stderr
 post_remove: line 5
+
 dkms: removing module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Module dkms_patches_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
 Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_patches_test.ko${mod_compression_ext}
+
 dkms: removing module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Module dkms_scripts_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
@@ -1765,6 +1783,7 @@ Before uninstall, this module version was ACTIVE on this kernel.
 Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_scripts_test.ko${mod_compression_ext}
 
 Running the post_remove script:
+
 Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_patches_test' << EOF
@@ -2604,6 +2623,7 @@ make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
 
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
+
 Autoinstall on ${KERNEL_VER} failed for module(s) dkms_failing_test(10).
 
 Error! One or more modules failed to install during autoinstall.
@@ -2626,6 +2646,7 @@ make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
 
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
+
 Autoinstall on ${KERNEL_VER} failed for module(s) dkms_failing_test(10).
 dkms_failing_dependencies_test/1.0 autoinstall failed due to missing dependencies: dkms_failing_test.
 
@@ -2698,6 +2719,7 @@ ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KE
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
+
 Autoinstall on ${KERNEL_VER} was skipped for module(s) dkms_build_exclusive_test.
 EOF
 run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
@@ -2720,6 +2742,7 @@ ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KE
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
+
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
@@ -2728,6 +2751,7 @@ ${SIGNING_MESSAGE}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test.
 Autoinstall on ${KERNEL_VER} was skipped for module(s) dkms_build_exclusive_test.
 EOF
@@ -2763,6 +2787,7 @@ ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KE
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
+
 Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
@@ -2772,6 +2797,7 @@ make -j1 KERNELRELEASE=${KERNEL_VER} all <omitting possibly set CC/LD/... flags>
 
 Error! Bad return status for module build on kernel: ${KERNEL_VER} (${KERNEL_ARCH})
 Consult /var/lib/dkms/dkms_failing_test/1.0/build/make.log for more information.
+
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}
 Cleaning build area... done.
@@ -2780,6 +2806,7 @@ ${SIGNING_MESSAGE}Cleaning build area... done.
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test.
 Autoinstall on ${KERNEL_VER} was skipped for module(s) dkms_build_exclusive_test.
 Autoinstall on ${KERNEL_VER} failed for module(s) dkms_failing_test(10).
@@ -2829,11 +2856,13 @@ ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KE
 for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
+
 Autoinstall of module dkms_build_exclusive_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 ${SIGNING_PROLOGUE}Warning: The /var/lib/dkms/dkms_build_exclusive_dependencies_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
 for module dkms_build_exclusive_dependencies_test/1.0 includes a BUILD_EXCLUSIVE directive
 which does not match this kernel/arch/config.
 This indicates that it should not be built.
+
 Autoinstall on ${KERNEL_VER} was skipped for module(s) dkms_build_exclusive_test dkms_build_exclusive_dependencies_test.
 EOF
 run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
@@ -3103,6 +3132,7 @@ Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Installing /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}
 Running depmod... done.
+
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_test.
 EOF
 run_with_expected_output dkms status << EOF

--- a/test/dkms_crlf_test-1.0/Makefile
+++ b/test/dkms_crlf_test-1.0/Makefile
@@ -1,0 +1,7 @@
+obj-m += dkms_dos_test.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/test/dkms_crlf_test-1.0/dkms.conf
+++ b/test/dkms_crlf_test-1.0/dkms.conf
@@ -1,0 +1,5 @@
+PACKAGE_NAME="dkms_crlf_test"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME[0]="dkms_dos_test"
+DEST_MODULE_LOCATION[0]="/kernel/extra"
+AUTOINSTALL="yes"

--- a/test/dkms_crlf_test-1.0/dkms_dos_test.c
+++ b/test/dkms_crlf_test-1.0/dkms_dos_test.c
@@ -1,0 +1,23 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+
+#define  DKMS_TEST_VER "1.0"
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("A Simple dkms test module");
+
+static int __init dkms_crlf_test_init(void)
+{
+    printk(KERN_INFO "DKMS Test Module -%s Loaded\n",DKMS_TEST_VER);
+    return 0;
+}
+
+static void __exit dkms_crlf_test_cleanup(void)
+{
+    printk(KERN_INFO "Cleaning up after dkms test module.\n");
+}
+
+module_init(dkms_crlf_test_init);
+module_exit(dkms_crlf_test_cleanup);
+MODULE_VERSION(DKMS_TEST_VER);

--- a/test/dkms_noisy_test-1.0/dkms.conf
+++ b/test/dkms_noisy_test-1.0/dkms.conf
@@ -1,5 +1,6 @@
 PACKAGE_NAME="dkms_noisy_test"
 PACKAGE_VERSION="1.0"
+CLEAN="make clean"
 BUILT_MODULE_NAME[0]="dkms_noisy_test"
 DEST_MODULE_LOCATION[0]="/kernel/extra"
 AUTOINSTALL="yes"


### PR DESCRIPTION
fix dkms.conf with CRLF (aka DOS) line endings

a few test improvements

improved output formatting: use blank lines to separate "global" operations and module/kernel combos, do not put unneccessary blank lines into a single module/kernel combo

emit the signing prologue only once for autoinstall with multiple modules

do not make this into a release, yet, I have two more PRs queued up that need to be rebased after the formatting changes: some make.log changes, shuffling and updating tests, probably somthing more from my todo list