### PR TITLE
Allow dkms to work in a chroot environment without /proc

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -2372,7 +2372,7 @@ run_match()
         fi
         maybe_build_module "$template_module" "$template_version" "$kernelver" "$arch"
         maybe_install_module "$template_module" "$template_version" "$kernelver" "$arch"
-    done < <(echo "$template_kernel_status")
+    done <<< "$(echo "$template_kernel_status")"
 }
 
 report_build_problem()

--- a/dkms.in
+++ b/dkms.in
@@ -874,7 +874,7 @@ check_version_sanity()
         fi
     fi
     set_module_suffix "$1"
-    read -a kernels_module < <(find_module "$lib_tree" "${4}")
+    read -a kernels_module <<< "$(find_module "$lib_tree" "${4}")"
     [[ -z $kernels_module ]] && return 0
 
     if [[ "$force_version_override" == "true" ]]; then

--- a/dkms.in
+++ b/dkms.in
@@ -2663,7 +2663,7 @@ kernel_prerm()
         echo "dkms: removing module $m/$v for kernel $kernelver ($arch)" >&2
         (module="$m" module_version="$v" unbuild_module) || failed="$failed $m/$v($?)"
         echo ""
-    done < <(list_module_version_combos)
+    done <<< "$(list_module_version_combos)"
 
     if [[ -f $dkms_tree/depmod-pending-$kernelver-$arch ]]; then
         rm -f $dkms_tree/depmod-pending-$kernelver-$arch

--- a/dkms.in
+++ b/dkms.in
@@ -1175,7 +1175,7 @@ prepare_build()
     for bd in "${BUILD_DEPENDS[@]}"; do
         while read status mvka; do
             [[ $status = installed ]] && continue 2
-        done < <(module_status "$bd" "*" "$kernelver" "$arch")
+        done <<< "$(module_status "$bd" "*" "$kernelver" "$arch")"
         bd_missing="$bd_missing $bd"
     done
     if [[ $bd_missing ]]; then

--- a/dkms.in
+++ b/dkms.in
@@ -787,7 +787,7 @@ get_module_verinfo(){
             srcver="${vals[1]}"
             ;;
     esac
-    done < <(modinfo "$1")
+    done <<< "$(modinfo "$1")"
 
     echo -E "${ver}"
     # Use obsolete checksum info if srcversion is not available

--- a/dkms.in
+++ b/dkms.in
@@ -2524,7 +2524,7 @@ autoinstall() {
         elif [[ ("$(VER "$v")" > "$(VER "${latest["$m"]}")") ]]; then
             latest["$m"]="$v"
         fi
-    done < <(module_status)
+    done <<< "$(module_status)"
 
     # Walk through our list of known modules, and create
     # a list of modules that need to be reinstalled.

--- a/dkms.in
+++ b/dkms.in
@@ -2050,7 +2050,7 @@ module_status() {
         is_module_added "$m" "$v" || continue
         ret=0
         module_status_built "$m" "$v" "$3" "$4" || echo "added $m/$v"
-    done < <(list_module_version_combos "$1" "$2")
+    done <<< "$(list_module_version_combos "$1" "$2")"
     return $ret
 }
 

--- a/dkms.in
+++ b/dkms.in
@@ -1929,7 +1929,7 @@ module_status_weak() {
     for weak_ko in "$install_tree/"*/weak-updates/*; do
         [[ -e $weak_ko ]] || continue
         [[ -L $weak_ko ]] && installed_ko="$(readlink -f "$weak_ko")" || continue
-        IFS=/ read m v k a < <(IFS=$oifs find_module_from_ko "$weak_ko") || continue
+        IFS=/ read m v k a <<< "$(IFS=$oifs find_module_from_ko "$weak_ko")" || continue
         kern=${weak_ko#$install_tree/}
         kern=${kern%/weak-updates/*}
         [[ $m = ${1:-*} && $v = ${2:-*} && $k = ${5:-*} && $a = ${4:-*} && $kern = ${3:-*} ]] || continue

--- a/dkms.in
+++ b/dkms.in
@@ -380,7 +380,7 @@ setup_kernels_arches()
             kernelver[$i]=${line%/*}
             arch[$i]=${line#*/}
             i=$(($i + 1))
-        done < <(module_status_built "$module" "$module_version" | sort -V)
+        done <<< "$(module_status_built "$module" "$module_version" | sort -V)"
     fi
 
     # Set default kernel version and arch, if none set (but only --all isn't set)

--- a/dkms.in
+++ b/dkms.in
@@ -1961,7 +1961,7 @@ do_status_weak()
     while read status mvka; do
         IFS=/ read m v k a kern <<< "$mvka"
         echo "$m, $v, $k, $a: installed-weak from $kern"
-    done < <(module_status_weak "$@")
+    done <<< "$(module_status_weak "$@")"
 }
 
 # Spit out all the extra status information that people running DKMS are

--- a/dkms.in
+++ b/dkms.in
@@ -2893,12 +2893,6 @@ done
 
 # Sanity checking
 
-# The <(cmd) idiom does not work if /proc is not mounted
-read line < <(echo "Hello, DKMS!")
-if [[ $line != "Hello, DKMS!" ]]; then
-    warn "dkms will not function properly if /proc is not mounted."
-fi
-
 # Error out if binaries-only is set and source-only is set
 if [[ $binaries_only && $source_only ]]; then
     die 8 "You have specified both --binaries-only and --source-only." \


### PR DESCRIPTION
I didn't author these changes; I'm just submitting the pull request (with the author's permission) in the hope that it can be merged with little or no discussion.

It's a fairly small and self-explanatory set of changes that, at least at first glance, shouldn't alter existing behaviour, just make dkms as a whole more robust by not requiring `/proc` to be mounted for it to work.