### PR TITLE
Various fixes for weak modules and SUSE

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -192,7 +192,7 @@ invoke_command()
     fi
 
     if [ -n "$progresspid" ]; then
-        kill "$progresspid" >/dev/null 2>&1
+        kill -9 "$progresspid" >/dev/null 2>&1
         wait "$progresspid" 2>/dev/null
     fi
 
@@ -333,9 +333,9 @@ set_module_suffix()
     # $1 = the kernel to base the module_suffix on
     kernel_test="${1:-$(uname -r)}"
     module_uncompressed_suffix=".ko"
-    find $install_tree/$kernel_test/ -name "*.ko.gz" | grep -q . && module_compressed_suffix=".gz"
-    find $install_tree/$kernel_test/ -name "*.ko.xz" | grep -q . && module_compressed_suffix=".xz"
-    find $install_tree/$kernel_test/ -name "*.ko.zst" | grep -q . && module_compressed_suffix=".zst"
+    find $install_tree/$kernel_test/ -name "*.ko.gz" 2>/dev/null | grep -q . && module_compressed_suffix=".gz"
+    find $install_tree/$kernel_test/ -name "*.ko.xz" 2>/dev/null | grep -q . && module_compressed_suffix=".xz"
+    find $install_tree/$kernel_test/ -name "*.ko.zst" 2>/dev/null | grep -q . && module_compressed_suffix=".zst"
     module_suffix="$module_uncompressed_suffix$module_compressed_suffix"
 }
 

--- a/dkms.in
+++ b/dkms.in
@@ -1512,9 +1512,9 @@ do_install()
 
     # Add to kabi-tracking
     if [[ -z $NO_WEAK_MODULES ]]; then
-        if [[ ${weak_modules} ]]; then
-            echo "Adding any weak-modules"
-            list_each_installed_module "$module" "$kernelver" "$arch" | ${weak_modules} ${weak_modules_no_initrd} --add-modules
+        if [[ ${weak_modules_add} ]]; then
+            echo "Adding linked weak modules..."
+            list_each_installed_module "$module" "$kernelver" "$arch" | ${weak_modules_add}
         fi
     fi
 
@@ -1723,9 +1723,9 @@ do_uninstall()
         echo "Before uninstall, this module version was ACTIVE on this kernel."
         # remove kabi-tracking if last instance removed
         if [[ -z $NO_WEAK_MODULES ]]; then
-            if [[ ${weak_modules} ]] && (module_status_built $module $module_version |grep -q "installed"); then
-                echo "Removing any linked weak-modules"
-                list_each_installed_module "$module" "$1" "$2" | ${weak_modules} ${weak_modules_no_initrd} --remove-modules
+            if [[ ${weak_modules_remove} ]] && (module_status_built $module $module_version |grep -q "installed"); then
+                echo "Removing linked weak modules..."
+                list_each_installed_module "$module" "$1" "$2" | ${weak_modules_remove}
             fi
         fi
 
@@ -1906,8 +1906,8 @@ find_module_from_ko()
 module_status_weak() {
     # $1 = module, $2 = module version, $3 = kernel version weak installed to,
     # $4 = kernel arch, $5 = kernel version built for
-    [[ -z $NO_WEAK_MODULES ]] || return 1
-    [[ $weak_modules ]] || return 1
+    [[ -n $NO_WEAK_MODULES ]] || return 1
+    [[ $weak_modules_add ]] && [[ $weak_modules_remove ]] || continue
     local m
     local v
     local k
@@ -2714,7 +2714,6 @@ rm -f "$tmpfile"
 # These can come from the environment or the config file
 [[ ! ${ADDON_MODULES_DIR} && -e /etc/sysconfig/module-init-tools ]] && . /etc/sysconfig/module-init-tools
 addon_modules_dir="${ADDON_MODULES_DIR}"
-weak_modules="${WEAK_MODULES_BIN}"
 
 # Source in configuration not related to signing
 read_framework_conf $dkms_framework_nonsigning_variables
@@ -2741,13 +2740,12 @@ module_uncompressed_suffix=""
 module_compressed_suffix=""
 rpm_safe_upgrade=""
 declare -a directive_array=() kernelver=() arch=()
-weak_modules=''
+weak_modules_add=''
+weak_modules_remove=''
 last_mvka=''
 last_mvka_conf=''
 try_source_tree=''
 die_is_fatal="yes"
-[ -x /sbin/weak-modules ] && weak_modules='/sbin/weak-modules'
-[ -x /usr/lib/module-init-tools/weak-modules ] && weak_modules='/usr/lib/module-init-tools/weak-modules'
 no_depmod=""
 delayed_depmod=""
 prepared_kernel="none"
@@ -2921,11 +2919,6 @@ if [[ $arch && $all ]]; then
         "--all on the command line."
 fi
 
-# Since initramfs/initrd rebuild is not requested, skip it with Redhat's weak-modules
-if [[ $weak_modules ]]; then
-    weak_modules_no_initrd="--no-initramfs"
-fi
-
 # Default to -j<number of CPUs>
 parallel_jobs=${parallel_jobs:-$(get_num_cpus)}
 
@@ -2936,6 +2929,23 @@ parallel_jobs=${parallel_jobs:-$(get_num_cpus)}
 [[ $action =~ kernel_(postinst|prerm) ]] && have_one_kernel "$action"
 
 setup_kernels_arches "$action"
+
+# Since initramfs/initrd rebuild is not requested, skip it with Redhat's weak-modules
+if [[ -z $NO_WEAK_MODULES ]]; then
+    case "$running_distribution" in
+    rhel*)
+        weak_modules_add='/usr/sbin/weak-modules --no-initramfs --add-modules'
+        weak_modules_remove='/usr/sbin/weak-modules --no-initramfs --remove-modules'
+        ;;
+    sles* | suse* | opensuse*)
+        weak_modules_add='/usr/lib/module-init-tools/weak-modules2 --add-kernel-modules ${kernelver}'
+        weak_modules_remove='/usr/lib/module-init-tools/weak-modules2 --remove-kernel-modules ${kernelver}'
+        ;;
+    *)
+        ;;
+    esac
+fi
+
 case "$action" in
 remove | unbuild | uninstall)
     check_module_args $action

--- a/dkms.in
+++ b/dkms.in
@@ -1767,16 +1767,11 @@ do_uninstall()
     fi
 
     # Delete the original_module if nothing for this kernel is installed anymore
-    if [[ $was_active && -d $dkms_tree/$module/original_module/$1/$2 && ! -d $dkms_tree/$module/original_module/$1/$2/collisions ]]; then
+    if [[ $was_active && -d $dkms_tree/$module/original_module/$1/$2 ]]; then
         echo ""
-        echo "Removing original_module from DKMS tree for kernel $1 ($2)"
+        echo "Removing original module(s) from DKMS tree for kernel $1 ($2)"
         rm -rf "$dkms_tree/$module/original_module/$1/$2" 2>/dev/null
         [[ $(find $dkms_tree/$module/original_module/$1/* -maxdepth 0 -type d 2>/dev/null) ]] || rm -rf "$dkms_tree/$module/original_module/$1"
-    elif [[ $was_active && -d $dkms_tree/$module/original_module/$1/$2/collisions ]]; then
-        echo ""
-        echo "Keeping directory $dkms_tree/$module/original_module/$1/$2/collisions/"
-        echo "for your reference purposes.  Your kernel originally contained multiple"
-        echo "same-named modules and this directory is now where these are located."
     fi
     [[ $(find $dkms_tree/$module/original_module/* -maxdepth 0 -type d 2>/dev/null) ]] || rm -rf "$dkms_tree/$module/original_module"
 }

--- a/run_test.sh
+++ b/run_test.sh
@@ -1878,7 +1878,7 @@ Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compr
 Restoring archived original module
 Running depmod... done.
 
-Removing original_module from DKMS tree for kernel ${KERNEL_VER} (${KERNEL_ARCH})
+Removing original module(s) from DKMS tree for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 EOF
 if [ "${expected_dest_loc}" != "kernel/extra" ]; then
     # A replaced module originating from a kernel image should get restored
@@ -1935,7 +1935,7 @@ Deleting /lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compr
 Restoring archived original module
 Running depmod... done.
 
-Removing original_module from DKMS tree for kernel ${KERNEL_VER} (${KERNEL_ARCH})
+Removing original module(s) from DKMS tree for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 
 Deleting module dkms_replace_test/2.0 completely from the DKMS tree.
 EOF

--- a/run_test.sh
+++ b/run_test.sh
@@ -187,9 +187,9 @@ run_status_with_expected_output() {
 generalize_expected_output() {
     local output_log=$1
 
-    # On CentOS, weak-modules is executed. Drop it from the output, to be more generic
-    sed -i '/^Adding any weak-modules$/d' ${output_log}
-    sed -i '/^Removing any linked weak-modules$/d' ${output_log}
+    # On Red Hat and SUSE based distributions, weak-modules is executed. Drop it from the output, to be more generic
+    sed -i '/^Adding linked weak modules.*$/d' ${output_log}
+    sed -i '/^Removing linked weak modules.*$/d' ${output_log}
     # Signing related output. Drop it from the output, to be more generic
     if (( NO_SIGNING_TOOL == 0 )); then
         sed -i '/^EFI variables are not supported on this system/d' ${output_log}


### PR DESCRIPTION
- Fix variable check when determining if `NO_WEAK_MODULES` is set to trigger the whole weak module process.
- kABI is available only on SUSE and RHEL platforms, so avoid setting parameters for all other distributions.
- For SUSE, use the new script provided in `suse-module-tools` and not the one provided by `suse-module-tools-legacy`.
- Avoid issues with output being redirected when invoking DKMS via RPM scriptlet on SUSE platforms.
- Avoid issues of processes not getting killed on SUSE platforms.
- When deleting a kernel, also delete multiple original modules (collisions folder).