### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,8 +52,9 @@ jobs:
 
     - name: Install dependencies for Red Hat based distributions
       if: matrix.distro.name == 'almalinux' || contains(matrix.distro.name, 'centos') || contains(matrix.distro.name, 'fedora')
+      # Allowerasing in place for differences between container only packages and full packages
       run: |
-        yum install -y diffutils elfutils-libelf gcc kernel kernel-devel make openssl patch
+        yum install -y --allowerasing diffutils elfutils-libelf gcc kernel kernel-devel make openssl patch
         make install-redhat
 
     - name: Install Alpine dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       if: matrix.distro.name == 'almalinux' || contains(matrix.distro.name, 'centos') || contains(matrix.distro.name, 'fedora')
       # Allowerasing in place for differences between container only packages and full packages
       run: |
-        yum install -y --allowerasing diffutils elfutils-libelf gcc kernel kernel-devel make openssl patch
+        yum install -y --allowerasing gawk diffutils elfutils-libelf gcc kernel kernel-devel make openssl patch
         make install-redhat
 
     - name: Install Alpine dependencies

--- a/dkms.in
+++ b/dkms.in
@@ -1922,42 +1922,43 @@ module_status_weak() {
     # $1 = module, $2 = module version, $3 = kernel version weak installed to,
     # $4 = kernel arch, $5 = kernel version built for
     [[ -n $NO_WEAK_MODULES ]] || return 1
-    [[ $weak_modules_add ]] && [[ $weak_modules_remove ]] || continue
-    local m
-    local v
-    local k
-    local a
-    local kern
-    local weak_ko
-    local mod
-    local installed_ko
-    local f
-    local ret
-    local oifs
-    ret=1
-    oifs=$IFS
+    if [[ $weak_modules_add && $weak_modules_remove ]]; then
+        local m
+        local v
+        local k
+        local a
+        local kern
+        local weak_ko
+        local mod
+        local installed_ko
+        local f
+        local ret
+        local oifs
+        ret=1
+        oifs=$IFS
 
-    local -A already_found
-    for weak_ko in "$install_tree/"*/weak-updates/*; do
-        [[ -e $weak_ko ]] || continue
-        [[ -L $weak_ko ]] && installed_ko="$(readlink -f "$weak_ko")" || continue
-        IFS=/ read m v k a < <(IFS=$oifs find_module_from_ko "$weak_ko") || continue
-        kern=${weak_ko#$install_tree/}
-        kern=${kern%/weak-updates/*}
-        [[ $m = ${1:-*} && $v = ${2:-*} && $k = ${5:-*} && $a = ${4:-*} && $kern = ${3:-*} ]] || continue
-        already_found[$m/$v/$kern/$a/$k]+=${weak_ko##*/}" "
-    done
-    # Check to see that all ko's are present for each module
-    for mod in ${!already_found[@]}; do
-        IFS=/ read m v k a kern <<< "$mod"
-        # ensure each module is weak linked
-        for installed_ko in $(find $dkms_tree/$m/$v/$kern/$a/module -type f); do
-            [[ ${already_found[$mod]} != *"$installed_ko"* ]] && continue 2
+        local -A already_found
+        for weak_ko in "$install_tree/"*/weak-updates/*; do
+            [[ -e $weak_ko ]] || continue
+            [[ -L $weak_ko ]] && installed_ko="$(readlink -f "$weak_ko")" || continue
+            IFS=/ read m v k a < <(IFS=$oifs find_module_from_ko "$weak_ko") || continue
+            kern=${weak_ko#$install_tree/}
+            kern=${kern%/weak-updates/*}
+            [[ $m = ${1:-*} && $v = ${2:-*} && $k = ${5:-*} && $a = ${4:-*} && $kern = ${3:-*} ]] || continue
+            already_found[$m/$v/$kern/$a/$k]+=${weak_ko##*/}" "
         done
-        ret=0
-        echo "installed-weak $mod"
-    done
-    return $ret
+        # Check to see that all ko's are present for each module
+        for mod in ${!already_found[@]}; do
+            IFS=/ read m v k a kern <<< "$mod"
+            # ensure each module is weak linked
+            for installed_ko in $(find $dkms_tree/$m/$v/$kern/$a/module -type f); do
+                [[ ${already_found[$mod]} != *"$installed_ko"* ]] && continue 2
+            done
+            ret=0
+            echo "installed-weak $mod"
+        done
+        return $ret
+    fi
 }
 
 # Print the requested status lines for weak-installed modules.


### PR DESCRIPTION
- Do not use `continue` out of a loop (#488).
- Tests, Red Hat based containers:
  - Add `--allowerasing` to `dnf` command line, Fedora Rawhide has specific `systemd` packages for containers and normal systems.
  - Add `gawk` as a dependency as it's no longer in the Fedora Rawhide image.