### PR TITLE
Report kernel module signing errors to prevent silent failures

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1382,7 +1382,9 @@ prepare_and_actual_build()
 
         if (( do_signing )); then
             echo "Signing module $built_module"
-            "$sign_file" "$sign_hash" "$mok_signing_key" "$mok_certificate" "$built_module" 2>/dev/null
+            if ! signing_command_output=$("$sign_file" "$sign_hash" "$mok_signing_key" "$mok_certificate" "$built_module" 2>&1); then
+                warn "Failed to sign module '$built_module'!" "$signing_command_output"
+            fi
         fi
 
         if [[ $module_compressed_suffix = .gz ]]; then


### PR DESCRIPTION
This PR improves the kernel module signing process by ensuring failures are properly detected and reported. Previously, dkms suppressed the signing command output and did not check the exit status, leading to silent failures. This was a personal issue for me, as I had a malformed X.509 certificate and spent an hour debugging why dkms wasn't signing kernel modules. Now, if signing fails, a clear error is displayed along with the signing command output for easier debugging. These changes were tested successfully on Fedora Linux (6.12.13-200.fc41.x86_64).