### PR TITLE
dkms.in: try to find Gentoo's module signing key and certificate

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -404,7 +404,7 @@ setup_kernels_arches()
         fi
         if [[ ${#arch[@]} -eq 0 ]]; then
             case "$running_distribution" in
-                debian* | ubuntu* | arch*)
+                debian* | ubuntu* | arch* | gentoo*)
                     arch[0]=$(uname -m)
                     ;;
                 *)
@@ -1100,7 +1100,26 @@ prepare_mok()
                     SHIM_NOTRIGGER=y update-secureboot-policy --new-key &>/dev/null
                     update-secureboot-policy --enroll-key
                 fi
+                ;;
+            gentoo* )
+                # If the usual Gentoo/Portage environment variables are set, use those.
+                mok_signing_key=${MODULES_SIGN_KEY}
+                mok_certificate=${MODULES_SIGN_CERT}
 
+                # If still empty, attempt to read the signing configuration set for portage.
+                if [[ -z "${mok_signing_key}" && -f /etc/portage/make.conf ]]; then
+                    mok_signing_key=$(grep "^MODULES_SIGN_KEY=" /etc/portage/make.conf | cut -f2 -d= | sed 's/"//g')
+                fi
+                if [[ -z "${mok_certificate}" && -f /etc/portage/make.conf ]]; then
+                    mok_certificate=$(grep "^MODULES_SIGN_CERT=" /etc/portage/make.conf | cut -f2 -d= | sed 's/"//g')
+                fi
+
+                if [[ -z "${mok_signing_key}" && -f ${kernel_config} ]]; then
+                    mok_signing_key=$(grep "^CONFIG_MODULE_SIG_KEY=" "${kernel_config}" | cut -f2 -d= | sed 's/"//g')
+                    # Kernel module signing facility requires PEM files containing both
+                    # the key and the certificate, so in this case both will be the same.
+                    mok_certificate=${mok_signing_key}
+                fi
                 ;;
         esac
     fi
@@ -1166,6 +1185,9 @@ prepare_signing()
                 if [[ ! -x "${sign_file}" ]]; then
                     sign_file="/usr/src/linux-headers-$kernelver/scripts/sign-file"
                 fi
+                ;;
+            gentoo* )
+                sign_file="/usr/src/linux-$kernelver/scripts/sign-file"
                 ;;
         esac
         if [[ ! -f ${sign_file} ]]; then
@@ -1791,7 +1813,7 @@ do_uninstall()
                 done
 
                 case "$running_distribution" in
-                    debian* | ubuntu* | arch*)
+                    debian* | ubuntu* | arch* | gentoo*)
                         (if cd "$install_tree/$1"; then rmdir -p --ignore-fail-on-non-empty "${dir_to_remove}"; fi || true)
                         ;;
                     *)

--- a/run_test.sh
+++ b/run_test.sh
@@ -335,6 +335,8 @@ fi
 os_id="$(sed -n 's/^ID\s*=\s*\(.*\)$/\1/p' /etc/os-release | tr -d '"')"
 shows_errors=yes
 distro_sign_file_candidates=
+distro_modsigkey=/var/lib/dkms/mok.key
+distro_modsigcert=/var/lib/dkms/mok.pub
 case "${os_id}" in
     centos | fedora | rhel | ovm | almalinux)
         expected_dest_loc=extra
@@ -364,6 +366,11 @@ case "${os_id}" in
     gentoo)
         expected_dest_loc=kernel/extra
         mod_compression_ext=
+        distro_sign_file_candidates="/usr/src/linux-${KERNEL_VER}/scripts/sign-file"
+        distro_modsigkey=/root/kernel_key.pem
+        distro_modsigcert=/root/kernel_cert.pem
+        echo "MODULES_SIGN_KEY=${distro_modsigkey}" >> /etc/portage/make.conf
+        echo "MODULES_SIGN_CERT=${distro_modsigcert}" >> /etc/portage/make.conf
         ;;
     *)
         echo >&2 "Error: unknown Linux distribution ID ${os_id}"
@@ -390,8 +397,8 @@ do
 done
 
 SIGNING_PROLOGUE_command="Sign command: ${sign_file}"
-SIGNING_PROLOGUE_key="Signing key: /var/lib/dkms/mok.key"
-SIGNING_PROLOGUE_cert="Public certificate (MOK): /var/lib/dkms/mok.pub"
+SIGNING_PROLOGUE_key="Signing key: ${distro_modsigkey}"
+SIGNING_PROLOGUE_cert="Public certificate (MOK): ${distro_modsigcert}"
 if [ "${sign_file}" = "/usr/bin/kmodsign" ]; then
     SIGNING_PROLOGUE_key="Signing key: /var/lib/shim-signed/mok/MOK.priv"
     SIGNING_PROLOGUE_cert="Public certificate (MOK): /var/lib/shim-signed/mok/MOK.der"


### PR DESCRIPTION
Just a little optimization for Gentoo so users don't have to configure the signing key and certificate in two places (with the package manager and in dkms `framework.conf`). Since we are now adding Gentoo cases for `$running_distribution` anyway, add those to some other places as well to avoid trying to call `rpm` unnecessarily.

See-also: https://github.com/gentoo/gentoo/pull/40704