### PR TITLE
Fix disable autoinstall for a single module when AUTOINSTALL='no' is set

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -2640,7 +2640,7 @@ autoinstall() {
         fi
         # If the module does not want to be autoinstalled, skip it.
         module=$m module_version=$v read_conf_or_die "${kernelver[0]}" "${arch[0]}" "$dkms_tree/$m/$v/source/dkms.conf"
-        if [[ ! $AUTOINSTALL ]]; then
+        if [[ ! $AUTOINSTALL || $AUTOINSTALL == "no" ]]; then
             continue
         fi
         # Otherwise, autoinstall the latest version we have hanging around.


### PR DESCRIPTION
When we want to specifically disable the autoinstall functionality for a certain module, we can either remove the AUTOINSTALL-related settings from the module's dkms.conf file or set `AUTOINSTALL="no"`. However, the current `autoinstall` function does not handle this properly. In other words, even if a module has `AUTOINSTALL="no"`, it will still be automatically installed, which is not the expected behavior.