### PR TITLE
Update tests.yml for Red Hat based distributions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,13 +24,13 @@ jobs:
           - {name: "archlinux", tag: "latest"}
           - {name: "archlinux", tag: "latest", variant: "-lts"}
           - {name: "archlinux", tag: "latest", variant: "-zen"}
-          - {name: "centos/centos", tag: "stream9", url: "quay.io/"}
-          - {name: "centos/centos", tag: "stream10", url: "quay.io/"}
+          - {name: "centos", tag: "stream10", url: "quay.io/centos/"}
+          - {name: "centos", tag: "stream9", url: "quay.io/centos/"}
           - {name: "debian", tag: "testing"}
           - {name: "debian", tag: "12"}
-          - {name: "fedora/fedora", tag: "rawhide", url: "quay.io/"}
-          - {name: "fedora/fedora", tag: "41", url: "quay.io/"}
-          - {name: "fedora/fedora", tag: "40", url: "quay.io/"}
+          - {name: "fedora", tag: "rawhide", url: "registry.fedoraproject.org/"}
+          - {name: "fedora", tag: "41", url: "registry.fedoraproject.org/"}
+          - {name: "fedora", tag: "40", url: "registry.fedoraproject.org/"}
           - {name: "gentoo/stage3", tag: "latest"}
           - {name: "opensuse/tumbleweed", tag: "latest", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "opensuse/leap", tag: "15.6", variant: "-default", url: "registry.opensuse.org/"}
@@ -51,10 +51,11 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies for Red Hat based distributions
-      if: matrix.distro.name == 'almalinux' || contains(matrix.distro.name, 'centos') || contains(matrix.distro.name, 'fedora')
-      # Allowerasing in place for differences between container only packages and full packages
+      if: matrix.distro.name == 'almalinux' || matrix.distro.name == 'centos' || matrix.distro.name == 'fedora'
+      # Relax crypto policies on Fedora 43+ to allow RSA signatures
       run: |
-        yum install -y --allowerasing gawk diffutils elfutils-libelf gcc kernel kernel-devel make openssl patch
+        dnf install -y gawk diffutils elfutils-libelf gcc kernel kernel-devel make openssl patch crypto-policies-scripts
+        update-crypto-policies --set LEGACY
         make install-redhat
 
     - name: Install Alpine dependencies


### PR DESCRIPTION
- Update registry URLs for Fedora and CentOS.
- Update DNF command for Red Hat based distributions.
- Relax crypto policies to allow again RSA signatures in Fedora 43+ (https://github.com/dell/dkms/issues/503).
  - I guess this is a temporary workaround as the maximum key strength allowed by the [UEFI specification](https://uefi.org/specs/UEFI/2.10/37_Secure_Technologies.html) is still RSA with a 3072 bits key and SHA256. Not sure what is the plan for Fedora 43 exactly.