### PR TITLE
Add codeSigning EKU to generated MOK

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ By default, DKMS generates a self signed certificate for signing modules at
 build time and signs every module that it builds before it gets compressed in
 the configured kernel compression mechanism of choice.
 
-This requires the `openssl` command to be present on the system.
+This requires version 1.1.1 or newer of the `openssl` command to be present on
+the system.
 
 Private key and certificate are auto generated the first time DKMS is run and
 placed in `/var/lib/dkms`. These certificate files can be pre-populated with

--- a/dkms.in
+++ b/dkms.in
@@ -1141,9 +1141,17 @@ prepare_mok()
             echo "openssl not found, can't generate key and certificate."
             return 1
         fi
+        # Newer openSUSE kernels require the codeSigning EKU
         openssl req -new -x509 -nodes -days 36500 -subj "/CN=DKMS module signing key" \
             -newkey rsa:2048 -keyout "$mok_signing_key" \
+            -addext "extendedKeyUsage=codeSigning" \
             -outform DER -out "$mok_certificate" > /dev/null 2>&1
+        if [[ ! -f ${mok_signing_key} ]]; then
+            # The addExt argument is supported on openssl 1.1.1 and newer.  Try again without it.
+            openssl req -new -x509 -nodes -days 36500 -subj "/CN=DKMS module signing key" \
+                -newkey rsa:2048 -keyout "$mok_signing_key" \
+                -outform DER -out "$mok_certificate" > /dev/null 2>&1
+        fi
         if [[ ! -f ${mok_signing_key} ]]; then
             echo "Key file ${mok_signing_key} not found and can't be generated, modules won't be signed"
             return 1

--- a/dkms.in
+++ b/dkms.in
@@ -1141,17 +1141,11 @@ prepare_mok()
             echo "openssl not found, can't generate key and certificate."
             return 1
         fi
-        # Newer openSUSE kernels require the codeSigning EKU
+        # Requires OpenSSL >= 1.1.1 for -addext
         openssl req -new -x509 -nodes -days 36500 -subj "/CN=DKMS module signing key" \
             -newkey rsa:2048 -keyout "$mok_signing_key" \
             -addext "extendedKeyUsage=codeSigning" \
             -outform DER -out "$mok_certificate" > /dev/null 2>&1
-        if [[ ! -f ${mok_signing_key} ]]; then
-            # The addExt argument is supported on openssl 1.1.1 and newer.  Try again without it.
-            openssl req -new -x509 -nodes -days 36500 -subj "/CN=DKMS module signing key" \
-                -newkey rsa:2048 -keyout "$mok_signing_key" \
-                -outform DER -out "$mok_certificate" > /dev/null 2>&1
-        fi
         if [[ ! -f ${mok_signing_key} ]]; then
             echo "Key file ${mok_signing_key} not found and can't be generated, modules won't be signed"
             return 1


### PR DESCRIPTION
Newer versions of openSUSE [require the `codeSigning` EKU on the module signing certificate](https://en.opensuse.org/openSUSE:UEFI#Signing_kernel_module).  This change will first attempt to set this value using the openssl `addext` argument.  If that fails, it will fall back to the previous openssl incanation.