### PR TITLE
fix dkms getting stuck with an incomplete $m/$v/$k/$a/module/ directory

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -1588,10 +1588,10 @@ do_install()
     # If the module is set to be force-installed
     local ret
     ret=$(force_installation "$module")
-    if [[ "$ret" == "force" ]];then
+    if [[ "$ret" == "force" ]]; then
         force="true"
         echo "Forcing installation of $module"
-    elif [[ "$ret" == "version-override" ]];then
+    elif [[ "$ret" == "version-override" ]]; then
         force_version_override="true"
         echo "Forcing version override of $module"
     fi
@@ -1602,6 +1602,7 @@ do_install()
         "You cannot install a module onto a non-existant kernel."
 
     # Read the conf file
+    set_module_suffix "$kernelver"
     read_conf_strict_or_die "$kernelver" "$arch"
 
     # Validate build completeness
@@ -1910,7 +1911,9 @@ do_uninstall()
 
     echo "Module $module/$module_version for kernel $1 ($2):"
 
+    # Read the conf file
     set_module_suffix "$1"
+    read_conf_or_die "$1" "$2"
 
     # If kernel-<kernelver> symlink points to this module, check for original_module and put it back
     local was_active

--- a/dkms.in
+++ b/dkms.in
@@ -1444,7 +1444,7 @@ do_build()
 
     # Build success, so create DKMS structure for a built module
     mkdir -p "$kernelver_dir"
-    local -r tmp_base_dir=$(mktemp_or_die -d "$kernelver_dir/tmp_${arch}_XXXXXX")
+    local -r tmp_base_dir=$(mktemp_or_die -d "$kernelver_dir/.tmp_${arch}_XXXXXX")
     mkdir -p "$tmp_base_dir/log"
     [[ $kernel_config ]] && cp -f "$kernel_config" "$tmp_base_dir/log/"
 
@@ -2076,7 +2076,7 @@ unbuild_module()
 remove_module()
 {
     # Clean up leftover temporary directories
-    rm -rf "${dkms_tree:?}/$module/$module_version"/*/tmp_*
+    rm -rf "${dkms_tree:?}/$module/$module_version"/*/.tmp_*
     find "$dkms_tree/$module/$module_version/" -maxdepth 1 -type d -empty -delete
 
     # Do --rpm_safe_upgrade check (exit out and don't do remove if inter-release RPM upgrade scenario occurs)

--- a/dkms.in
+++ b/dkms.in
@@ -1780,19 +1780,6 @@ is_module_built() {
     local d
     d="$dkms_tree/$1/$2/$3/$4"
     [[ -d $d/module ]] || return 1
-    local default_conf
-    default_conf="$dkms_tree/$1/$2/source/dkms.conf"
-    # If a custom dkms.conf was specified use it, otherwise use the default one.
-    local real_conf
-    real_conf="${conf:-${default_conf}}"
-    read_conf_or_die "$3" "$4" "$real_conf"
-    set_module_suffix "$3"
-    local m
-    for m in "${dest_module_name[@]}"; do
-        local t
-        t=$(compressed_or_uncompressed "$d/module" "$m")
-        [[ $t ]] || return 1
-    done
 }
 
 # This assumes we have already checked to see if the module has been built.

--- a/run_test.sh
+++ b/run_test.sh
@@ -195,7 +195,7 @@ generalize_expected_output() {
     local output_log=$1
 
     # Normalize temporary directories
-    sed -i "s|/\(tmp_${KERNEL_ARCH}\)_....../|/\1_XXXXXX/|g" "${output_log}"
+    sed -i "s|/\(\.tmp_${KERNEL_ARCH}\)_....../|/\1_XXXXXX/|g" "${output_log}"
     # On Red Hat and SUSE based distributions, weak-modules is executed. Drop it from the output, to be more generic
     sed -i '/^Adding linked weak modules.*$/d' "${output_log}"
     sed -i '/^Removing linked weak modules.*$/d' "${output_log}"

--- a/run_test.sh
+++ b/run_test.sh
@@ -3639,50 +3639,33 @@ rm "/var/lib/dkms/dkms_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/module/dkms_test.ko
 # if the module didn't exist in the build tree it probably wasn't installed either
 rm "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/dkms_test.ko${mod_compression_ext}"
 run_status_with_expected_output 'dkms_test' << EOF
-dkms_test/1.0: added
+dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: installed (Built modules are missing in the kernel modules folder)
 EOF
 
 echo 'Uninstalling the "incomplete" test module'
 run_with_expected_output dkms uninstall -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
-Module dkms_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
+Module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH}):
+Before uninstall, this module version was ACTIVE on this kernel.
+Module dkms_test.ko${mod_compression_ext} was not found within /lib/modules/${KERNEL_VER}/
+Running depmod... done.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
-dkms_test/1.0: added
+dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built (Built modules are missing in the kernel modules folder)
 EOF
 
 echo 'Installing the "incomplete" test module (expected error)'
-run_with_expected_error 3 dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
+run_with_expected_error 6 dkms install -k "${KERNEL_VER}" -m dkms_test -v 1.0 << EOF
 
-Error! This module/version has already been built on: ${KERNEL_VER}
-Directory /var/lib/dkms/dkms_test/1.0/${KERNEL_VER}/${KERNEL_ARCH} already exists. Use the dkms remove function before trying to build again.
+Error! Missing module dkms_test in /var/lib/dkms/dkms_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/module
 EOF
 run_status_with_expected_output 'dkms_test' << EOF
-dkms_test/1.0: added
+dkms_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built (Built modules are missing in the kernel modules folder)
 EOF
 
 echo 'Removing the "incomplete" test module with --all'
 run_with_expected_output dkms remove --all -m dkms_test -v 1.0 << EOF
-EOF
-run_status_with_expected_output 'dkms_test' << EOF
-dkms_test/1.0: added
-EOF
+Module dkms_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
 
-echo 'Adding the test module by version (expected error)'
-run_with_expected_error 3 dkms add -m dkms_test -v 1.0 << EOF
-
-Error! DKMS tree already contains: dkms_test/1.0
-You cannot add the same module/version combo more than once.
-EOF
-run_status_with_expected_output 'dkms_test' << EOF
-dkms_test/1.0: added
-EOF
-
-echo 'Manually cleaning up dkms tree'
-rm -rf /var/lib/dkms/dkms_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}
-rm -f /var/lib/dkms/dkms_test/kernel-${KERNEL_VER}-${KERNEL_ARCH}
-
-echo 'Removing the test module with --all'
-run_with_expected_output dkms remove --all -m dkms_test -v 1.0 << EOF
 Deleting module dkms_test/1.0 completely from the DKMS tree.
 EOF
 run_status_with_expected_output 'dkms_test' << EOF


### PR DESCRIPTION
Previous changes (using a tempdir in do_build) should have reduced the likelyhood that dkms gets stuck with an incomplete $m/$v/$k/$a/module/ directory.
But it didn't solve the case if dkms is already in such a state. `is_module_built` would return false and `remove_module` therefore does nothing, while `do_build` will refuse to do anything because the directory already exists.
Relax the check in `is_module_built` (there will be more thorough checks for completeness in `do_install`) to allow `remove_module` to clean up the mess.