### PR TITLE
DRAFT: Add logic for rebuilding modules when dependencies change

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -739,8 +739,24 @@ This optional directive is an array that allows you to specify other modules as
 dependencies for your module. Each array element should be the
 .B PACKAGE_NAME
 of another module that is managed by dkms. Do not specify a version or
-architecture in the dependency. Note that this directive is only advisory;
-missing or broken dependencies cause non-fatal warnings.
+architecture in the dependency. A missing dependency requires the parameter
+.OP --force
+to still attempt the build of the module.
+.TP
+.B BUILD_DEPENDS_REBUILD=
+If this directive is set to
+.B yes
+then the module which has
+.B BUILD_DEPENDS
+being set, will get rebuilt every time a dependency changes version. This is usually provided in a specific
+.I /etc/dkms/<module>.conf
+on a per installation basis.
+
+To keep track of the dependency change, the version of the module that was used at build time is recorded in the file
+.I /var/lib/dkms/<module>/<kernel_version>-<arch>/.dep_<dependency>.
+As soon as the module version changes, this is compared and the dependent module is rebuilt. With the parameter
+.I --force
+the dependency is not tracked.
 .TP
 .B BUILD_EXCLUSIVE_KERNEL=
 This optional directive allows you to specify a regular expression which defines

--- a/dkms.in
+++ b/dkms.in
@@ -93,7 +93,7 @@ readonly dkms_conf_variables="PACKAGE_NAME
    built_module_name BUILT_MODULE_LOCATION built_module_location
    DEST_MODULE_NAME dest_module_name
    DEST_MODULE_LOCATION dest_module_location
-   STRIP strip AUTOINSTALL NO_WEAK_MODULES
+   STRIP strip AUTOINSTALL NO_WEAK_MODULES BUILD_DEPENDS_REBUILD
 
    CLEAN
    REMAKE_INITRD MODULES_CONF MODULES_CONF_OBSOLETES
@@ -582,8 +582,7 @@ safe_source() {
 # Source a dkms.conf file and perform appropriate postprocessing on it.
 # Do our best to not repeatedly source the same .conf file -- this can happen
 # when chaining module installation functions or autoinstalling.
-read_conf()
-{
+read_conf() {
     # $1 kernel version (required)
     # $2 arch (required)
     # $3 dkms.conf location (optional)
@@ -844,6 +843,21 @@ read_conf()
             ;;
         *)
             echo "dkms.conf: Error! Unsupported NO_WEAK_MODULES value '$NO_WEAK_MODULES'" >&2
+            return_value=1
+            ;;
+    esac
+
+    # Check for allowed BUILD_DEPENDS_REBUILD values: "yes", "no", ""
+    case "$BUILD_DEPENDS_REBUILD" in
+        "")
+            ;;
+        [Yy][Ee][Ss])
+            ;;
+        [Nn][Oo])
+            BUILD_DEPENDS_REBUILD=""
+            ;;
+        *)
+            echo "dkms.conf: Error! Unsupported BUILD_DEPENDS_REBUILD value '$BUILD_DEPENDS_REBUILD'" >&2
             return_value=1
             ;;
     esac
@@ -1542,6 +1556,20 @@ do_build()
 
     # Clean the build directory
     rm -rf "${build_dir:?}"
+
+    # After successful build, save dependency versions
+    if [[ $BUILD_DEPENDS_REBUILD ]] && [[ ! $force ]]; then
+        mkdir -p "$base_dir"
+        for bd in "${BUILD_DEPENDS[@]}"; do
+            local dep_version
+            dep_version=$(module_status "$bd" "*" "$kernelver" "$arch" | while read -r status mvka; do
+                [[ $status ]] || continue
+                IFS='/' read -r m v k a <<< "$mvka"
+                echo "$v"
+            done | sort -V | tail -n1)
+            [[ $dep_version ]] && echo "$dep_version" > "$base_dir/.dep_${bd}"
+        done
+    fi
 }
 
 prepare_kernel_and_signing()
@@ -1755,6 +1783,9 @@ do_install()
 
     # Restore the status of $force
     force="$tmp_force"
+
+    # First check and rebuild any modules with updated dependencies
+    check_and_rebuild_dependent_modules "${kernelver[0]}" "${arch[0]}"
 }
 
 # List each kernel object that has been installed for a particular module.
@@ -2967,6 +2998,136 @@ kernel_prerm()
     [[ ! -d $install_tree/${kernelver[0]} ]] || find "$install_tree/${kernelver[0]}" -type d -empty -delete
 
     [[ ! $failed ]] || die 14 "dkms kernel_prerm for kernel ${kernelver[0]} (${arch[0]}) failed for module(s)$failed."
+}
+
+# Check if a module's dependencies have been updated
+check_dependencies_updated() {
+
+    local module=$1
+    local module_version=$2
+
+    # $1 = module
+    # $2 = module version
+    # $3 = kernel version
+    # $4 = arch
+
+    local deps_updated=0
+
+    # Read the module's configuration
+    set_module_suffix "$3"
+    read_conf_strict_or_die "$3" "$4"
+
+    # Check each dependency
+    for bd in "${BUILD_DEPENDS[@]}"; do
+        # Get the latest version of the dependency
+        local dep_version
+        dep_version=$(module_status "$bd" "*" "$3" "$4" | while read -r status mvka; do
+            [[ $status ]] || continue
+            IFS='/' read -r m v k a <<< "$mvka"
+            echo "$v"
+        done | sort -V | tail -n1)
+
+        # If dependency is not installed, skip it
+        [[ $dep_version ]] || continue
+
+        # Check if dependency's version has changed since last build
+        local dep_version_file="$dkms_tree/$module/$module_version/$3/$4/.dep_${bd}"
+        if [[ -f "$dep_version_file" ]]; then
+            local old_version
+            old_version=$(cat "$dep_version_file")
+            if [[ "$old_version" != "$dep_version" ]]; then
+                deps_updated=1
+                break
+            fi
+        else
+            deps_updated=1
+            break
+        fi
+    done
+
+    return $deps_updated
+}
+
+# Check and rebuild all modules with updated dependencies
+check_and_rebuild_dependent_modules() {
+
+    # $1 = kernel version
+    # $2 = arch
+
+    local -a modules_to_rebuild
+    local -a rebuilt_modules
+    local progress=1
+
+    # First pass: collect all modules that need rebuilding
+    while read -r status mvka; do
+        [[ $status ]] || continue
+        IFS='/' read -r m v k a <<< "$mvka"
+        # Skip if not built for this kernel/arch
+        [[ "$k" = "$1" && "$a" = "$2" ]] || continue
+
+        # Read module's configuration by passing module and version of the dependent module)
+        module=$m module_version=$v read_conf_or_die "$1" "$2"
+
+        # Skip if no BUILD_DEPENDS, BUILD_DEPENDS_REBUILD is not set or --force is passed
+        [[ ${#BUILD_DEPENDS[@]} -eq 0 ]] || [[ -z $BUILD_DEPENDS_REBUILD ]] || [[ $force ]] && continue
+
+        # Check if dependencies have been updated
+        if ! check_dependencies_updated "$m" "$v" "$1" "$2"; then
+            modules_to_rebuild+=("$m/$v")
+        fi
+    done <<< "$(module_status)"
+
+    # Second pass: rebuild modules in dependency order
+    while (( progress > 0 )); do
+        progress=0
+        local -a next_rebuild
+
+        # Remove already rebuilt modules from dependency lists
+        for mv in "${modules_to_rebuild[@]}"; do
+            IFS=/ read -r m v <<< "$mv"
+            module=$m module_version=$v read_conf_or_die "$1" "$2"
+
+            # Check if all dependencies are satisfied
+            # shellcheck disable=SC2034
+            local can_rebuild=1
+            for bd in "${BUILD_DEPENDS[@]}"; do
+                local dep_found=0
+                for rm in "${rebuilt_modules[@]}"; do
+                    IFS=/ read -r dm <<< "$rm"
+                    [[ "$dm" = "$bd" ]] && dep_found=1 && break
+                done
+                if (( ! dep_found )); then
+                    can_rebuild=0
+                    break
+                fi
+            done
+
+            if (( ! can_rebuild )); then
+                module=$m module_version=$v
+                echo ""
+                echo "Rebuilding module $m/$v due to updated dependencies"
+                echo ""
+                do_uninstall "$1" "$2"
+                do_unbuild "$1" "$2"
+                if do_build; then
+                    do_install
+                    rebuilt_modules+=("$m/$v")
+                    progress=1
+                fi
+            else
+                next_rebuild+=("$m/$v")
+            fi
+        done
+        modules_to_rebuild=("${next_rebuild[@]}")
+    done
+
+    # Report any modules that couldn't be rebuilt
+    if (( ${#modules_to_rebuild[@]} > 0 )); then
+        echo "Warning: The following modules could not be rebuilt due to dependency cycles:"
+        for mv in "${modules_to_rebuild[@]}"; do
+            echo "  $mv"
+        done
+    fi
 }
 
 #############################

--- a/test/dkms_dependencies_rebuild_test-1.0/Makefile
+++ b/test/dkms_dependencies_rebuild_test-1.0/Makefile
@@ -1,0 +1,7 @@
+obj-m += dkms_dependencies_rebuild_test.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/test/dkms_dependencies_rebuild_test-1.0/dkms.conf
+++ b/test/dkms_dependencies_rebuild_test-1.0/dkms.conf
@@ -1,0 +1,8 @@
+PACKAGE_NAME="dkms_dependencies_rebuild_test"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME[0]="dkms_dependencies_rebuild_test"
+DEST_MODULE_LOCATION[0]="/kernel/extra"
+AUTOINSTALL="yes"
+
+BUILD_DEPENDS="dkms_test"
+BUILD_DEPENDS_REBUILD="yes"

--- a/test/dkms_dependencies_rebuild_test-1.0/dkms_dependencies_rebuild_test.c
+++ b/test/dkms_dependencies_rebuild_test-1.0/dkms_dependencies_rebuild_test.c
@@ -1,0 +1,23 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+
+#define  DKMS_TEST_VER "1.0"
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("A Simple dkms test module with rebuild dependencies");
+
+static int __init dkms_dependencies_rebuild_test_init(void)
+{
+    printk(KERN_INFO "DKMS Test Module with rebuild dependencies -%s Loaded\n",DKMS_TEST_VER);
+    return 0;
+}
+
+static void __exit dkms_dependencies_rebuild_test_cleanup(void)
+{
+    printk(KERN_INFO "Cleaning up after dkms test module with rebuild dependencies.\n");
+}
+
+module_init(dkms_dependencies_rebuild_test_init);
+module_exit(dkms_dependencies_rebuild_test_cleanup);
+MODULE_VERSION(DKMS_TEST_VER);

--- a/test/dkms_test-2.0/Makefile
+++ b/test/dkms_test-2.0/Makefile
@@ -1,0 +1,7 @@
+obj-m += dkms_test.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/test/dkms_test-2.0/dkms.conf
+++ b/test/dkms_test-2.0/dkms.conf
@@ -1,0 +1,5 @@
+PACKAGE_NAME="dkms_test"
+PACKAGE_VERSION="2.0"
+BUILT_MODULE_NAME[0]="dkms_test"
+DEST_MODULE_LOCATION[0]="/kernel/extra"
+AUTOINSTALL="yes"

--- a/test/dkms_test-2.0/dkms_test.c
+++ b/test/dkms_test-2.0/dkms_test.c
@@ -1,0 +1,23 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+
+#define  DKMS_TEST_VER "2.0"
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("A Simple dkms test module");
+
+static int __init dkms_test_init(void)
+{
+    printk(KERN_INFO "DKMS Test Module -%s Loaded\n",DKMS_TEST_VER);
+    return 0;
+}
+
+static void __exit dkms_test_cleanup(void)
+{
+    printk(KERN_INFO "Cleaning up after dkms test module.\n");
+}
+
+module_init(dkms_test_init);
+module_exit(dkms_test_cleanup);
+MODULE_VERSION(DKMS_TEST_VER);


### PR DESCRIPTION
Force the rebuild of modules when `BUILD_DEPENDS_REBUILD` is set and modules declared in `BUILD_DEPENDS` change.

When a module is updated, all modules that depend on it need to be automatically rebuilt in the correct order.

This is **all gated** through`BUILD_DEPENDS_REBUILD`, which should be set on a per installation basis, for example:
```
$ cat /etc/dkms/<module1>.conf
BUILD_DEPENDS=<module2>
BUILD_DEPENDS_REBUILD=yes
```

Whenever `<module1>` is built and `BUILD_DEPENDS` is set, the version of the dependent module is saved in:
```
/var/lib/dkms/<module>/<kernel_version>-<arch>/.dep_<dependency>
```

In case this changes, a new function `check_and_rebuild_dependent_modules()` that is called at the end of `do_install()` does the following:

Makes a first pass to collect all modules that need to be rebuilt by:
- Iterating through all modules
- Checking if they have `BUILD_DEPENDS` specified
- Using the previously stored dependency file to see if they need to be rebuilt
  - A missing file it's equal to a different version (so a rebuild)

Then it does a second pass to rebuild modules in dependency order by:
- Maintaining a list of already rebuilt modules
- For each module to rebuild, checking if all its dependencies have been rebuilt
- Only rebuilding modules whose dependencies are satisfied
- Failures:
  - Reports any modules that couldn't be rebuilt due to circular dependencies
  - Continues with the process even if some modules couldn't be rebuilt

If the user runs a `build/install` command with the `--force` parameter for a module where `BUILD_DEPENDS` and `BUILD_DEPENDS_REBUILD` are specified, the program will behave as before, bypassing the check and not saving the dependency in the file.

Sample run:
```
$ dkms status
2nd/1.0.0, 6.13.9-200.fc41.x86_64, x86_64: installed
1st/1.0.0, 6.13.9-200.fc41.x86_64, x86_64: installed

$ cat /var/lib/dkms/evdi/kernel-6.13.9-200.fc41.x86_64-x86_64/.dep_1st
1.0.0

# dkms remove -m 1st/1.0.0
Module 1st/1.0.0for kernel 6.13.9-200.fc41.x86_64 (x86_64):
Before uninstall, this module version was ACTIVE on this kernel.
Deleting /lib/modules/6.13.9-200.fc41.x86_64/extra/1st.ko.xz
Running depmod.... done.

Deleting module 1st/1.0.0 completely from the DKMS tree.

# dkms install -m 1st/2.0.0
Creating symlink /var/lib/dkms/1st/2.0.0/source -> /usr/src/1st-2.0.0

Sign command: /lib/modules/6.13.9-200.fc41.x86_64/build/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub

Building module(s)... done.
Signing module /var/lib/dkms/1st/2.0.0/build/1st.ko
Cleaning build area... done.
Installing /lib/modules/6.13.9-200.fc41.x86_64/extra/1st.ko.xz
Running depmod.... done.

Rebuilding module 2nd/1.0.0 due to updated dependencies

Module 2nd/1.0.0 for kernel 6.13.9-200.fc41.x86_64 (x86_64):
Before uninstall, this module version was ACTIVE on this kernel.
Deleting /lib/modules/6.13.9-200.fc41.x86_64/extra/2nd.ko.xz
Running depmod.... done.
Building module(s).... done.
Signing module /var/lib/dkms/2nd/1.0.0/build/2nd.ko
Cleaning build area... done.
Installing /lib/modules/6.13.9-200.fc41.x86_64/extra/2nd.ko.xz
Running depmod.... done.

$ cat /var/lib/dkms/evdi/kernel-6.13.9-200.fc41.x86_64-x86_64/.dep_1st
2.0.0
```