### PR TITLE
dkms: propagate OBSOLETE_BY to BUILD_EXCLUSIVE_KERNEL_MAX

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -604,6 +604,12 @@ particular DKMS module. This can be specified as a particular upstream kernel or
 bump of a kernel. For example, "2.6.24" would be an upstream kernel and "2.6.24\-16" would
 represent an ABI bump for a kernel. Both are valid in this area.
 
+Please consider using
+.B BUILD_EXCLUSIVE_KERNEL_MAX
+instead of
+.B OBSOLETE_BY
+as the former is a more general approach to solve the same problem.
+
 Please avoid the use of
 .B OBSOLETE_BY
 wherever possible. It's use indicates a lack of proper module

--- a/dkms.in
+++ b/dkms.in
@@ -803,6 +803,7 @@ read_conf()
     done
 
     # Set build_exclude
+    [[ $obsolete_by && ! $BUILD_EXCLUSIVE_KERNEL_MAX ]] && BUILD_EXCLUSIVE_KERNEL_MAX=$obsolete_by
     [[ $BUILD_EXCLUSIVE_KERNEL && ! $1 =~ $BUILD_EXCLUSIVE_KERNEL ]] && build_exclude="yes"
     [[ $BUILD_EXCLUSIVE_KERNEL_MIN && "$(VER "$1")" < "$(VER "$BUILD_EXCLUSIVE_KERNEL_MIN")" ]] && build_exclude="yes"
     [[ $BUILD_EXCLUSIVE_KERNEL_MAX && "$(VER "$1")" > "$(VER "$BUILD_EXCLUSIVE_KERNEL_MAX")" ]] && build_exclude="yes"


### PR DESCRIPTION
do not attempt to build modules that won't be installed

That's all what I have ready for now, #499 will take more time. If you don't have anything else in the queue, we should make a new release with the bugfixes we have in main so far.