### PR TITLE
Add post_transaction command

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -939,6 +939,39 @@ Run no more than this number of jobs in parallel.
 .TP
 .B compress_gzip_opts, compress_xz_opts, compress_zstd_opts
 Control how modules are compressed. By default, the highest available level of compression is used.
+.TP
+.B post_transaction
+If the directive is set to any non null-value, the content of the directive will be executed with any command that change the content of the kernel modules folder, that is
+.B dkms autoinstall, dkms install
+and
+.B dkms remove/unbuild/uninstall.
+Can be used to trigger a global
+.B initrd
+rebuild or to call a script that performs some other tasks (calling
+.B kexec,
+triggering the restart of services not contained in a DKMS package, etc.). The command is constructed with the shell built-in
+.B eval
+and the variable
+.B $kernelver
+can be used to represent the target kernel version. Some examples:
+
+Regenerate the ram disk for the target kernel:
+.B post_transaction="dracut --force --kver $kernelver"
+(Red Hat style) or
+.B post_transaction="update-initramfs -k $kernelver"
+(Debian style).
+
+Launch an arbitrary script:
+.B post_transaction="/path/to/script.sh"
+
+Restart a service:
+.B post_transaction="systemctl restart something.service"
+
+Regenerate the ram disk for all installed kernels, ignoring the kernel version passed as the parameter:
+.B post_transaction="dracut --force --regenerate-all"
+(Red Hat style) or
+.B post_transaction="update-initramfs -k all"
+(Debian style).
 .SH DKMS AUTOINSTALLER
 The DKMS autoinstaller service (which can be
 .B dkms_autoinstaller

--- a/dkms.in
+++ b/dkms.in
@@ -102,11 +102,14 @@ show_deprecation_warnings=0
 
 # All of the variables not related to signing we will accept from framework.conf.
 readonly dkms_framework_nonsigning_variables="source_tree dkms_tree install_tree tmp_location
-   verbose symlink_modules autoinstall_all_kernels
-   modprobe_on_install parallel_jobs
-   compress_gzip_opts compress_xz_opts compress_zstd_opts"
+   verbose symlink_modules autoinstall_all_kernels modprobe_on_install parallel_jobs
+   compress_gzip_opts compress_xz_opts compress_zstd_opts
+   post_transaction"
 # All of the signing related variables we will accept from framework.conf.
 readonly dkms_framework_signing_variables="sign_file mok_signing_key mok_certificate"
+
+# The post transaction command we will accept from framework.conf
+readonly dkms_framework_post_transaction="post_transaction"
 
 # Some important regular expressions. Requires bash 3 or above.
 # Any poor souls still running bash 2 or older really need an upgrade.
@@ -3384,6 +3387,17 @@ if [[ ! $NO_WEAK_MODULES ]]; then
     esac
 fi
 
+# Execute post-transaction command if set and log its output
+execute_post_transaction() {
+    # Blank the log file before starting
+    : > "$dkms_tree/post_transaction.log"
+
+    # Lazy source in post_transaction related configuration
+    read_framework_conf "$dkms_framework_post_transaction"
+
+    invoke_command "$post_transaction" "Executing post-transaction command" "$dkms_tree/post_transaction.log" background
+}
+
 case "$action" in
     remove | unbuild | uninstall)
         check_module_args "$action"
@@ -3395,6 +3409,12 @@ case "$action" in
             check_rw_dkms_tree
         fi
         "${action}_module"
+        ret=$?
+        # Execute post_transaction command if set
+        if [[ $ret -eq 0 && -n "$post_transaction" ]]; then
+            execute_post_transaction
+        fi
+        exit $ret
         ;;
     add | build | install)
         check_all_is_banned "$action" # TODO: fix/enable --all
@@ -3405,10 +3425,22 @@ case "$action" in
             check_rw_dkms_tree
         fi
         "${action}_module"
+        ret=$?
+        # Execute post_transaction command if set
+        if [[ $ret -eq 0 && -n "$post_transaction" && $action = install ]]; then
+            execute_post_transaction
+        fi
+        exit $ret
         ;;
     autoinstall)
         have_one_kernel "$action"
         check_root && autoinstall
+        ret=$?
+        # Execute post_transaction command if set
+        if [[ $ret -eq 0 && -n "$post_transaction" ]]; then
+            execute_post_transaction
+        fi
+        exit $ret
         ;;
     match)
         check_root && have_one_kernel "match" && run_match

--- a/dkms.in
+++ b/dkms.in
@@ -1424,7 +1424,7 @@ do_build()
 
     # Apply any patches
     for p in "${patch_array[@]}"; do
-        [[ patches/$p == *"/../"* ]] &&
+        [[ patches/$p == *"/../"* ]] && \
             report_build_problem 5 \
             "Patch $p as specified in dkms.conf contains '..' path component."
         [[ ! -e $build_dir/patches/$p ]] && \

--- a/dkms_framework.conf.in
+++ b/dkms_framework.conf.in
@@ -34,8 +34,8 @@
 # Location of the key and certificate files used for Secure boot. $kernelver
 # can be used in path to represent the target kernel version.
 #
-# NOTE: If any of the files specified by `mok_signing_key` and
-# `mok_certificate` are non-existent, dkms will re-create both files.
+# NOTE: If any of the files specified by `mok_signing_key` and `mok_certificate`
+# are non-existent, dkms will re-create both files.
 #
 # mok_signing_key can also be a "pkcs11:..." string for PKCS#11 engine, as
 # long as the sign_file program supports it.
@@ -50,8 +50,15 @@
 # parallel_jobs=2
 
 # Compression settings DKMS uses when compressing modules. The defaults are
-# used, for reasonable compression times. One might instead wish to use
-# maximum compression, at the expense of speed when compressing.
+# used, for reasonable compression times. One might instead wish to use maximum
+# compression, at the expense of speed when compressing.
 # compress_gzip_opts="-6"
 # compress_xz_opts="--check=crc32 --lzma2=dict=1MiB -6"
 # compress_zstd_opts="-q --rm -T0 -3"
+
+# Command to run at the end of every DKMS transaction, for example after a new
+# kernel has been installed on the system and all modules have been succesfully
+# built and installed.
+# The command listed below is executed with the kernel version passed as a
+# parameter if set to any non null value:
+# post_transaction=""

--- a/test/framework/post_transaction.conf
+++ b/test/framework/post_transaction.conf
@@ -1,0 +1,1 @@
+post_transaction="echo This is a test message as post transaction. Kernel version is $kernelver"


### PR DESCRIPTION
Add a generic command that gets executed at the end of "install/uninstall" phases for modules. The `post_transaction` is configured in `/etc/dkms/framework.conf` and if set to any non-null value the command in there is executed with the kernel version that is the target of the command as the first parameter.

This can be set on a per-site or by distribution packagers of DKMS.

It's executed only at the end of commands that change the content of the kernel modules folder; so an `install`, `autoinstall` and `remove|unbuild|uninstall` command. When the directive is not set (the default) there is no behavior change for DKMS.

The action generates a log in the DKMS working directory using the facilities already provided by DKMS.

This originates from a need in NVIDIA for various components, (restarting services, recreating the `initrd`, etc.) but judging from a few Debian and Ubuntu packages I checked, this could remove all the `postinst` scripts that take care of calling `update-initramfs`, for example: https://salsa.debian.org/broadcom-sta-team/broadcom-sta/-/blob/debian/6.30.223.271-26/debian/broadcom-sta-common.postinst?ref_type=tags