### PR TITLE
Update tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
         distro:
           - {name: "almalinux", tag: "9"}
           - {name: "almalinux", tag: "8"}
+          - {name: "alpine", tag: "3.21", variant: "-lts"}
+          - {name: "alpine", tag: "3.21", variant: "-virt"}
           - {name: "alpine", tag: "3.20", variant: "-lts"}
           - {name: "alpine", tag: "3.20", variant: "-virt"}
           - {name: "alpine", tag: "3.19", variant: "-lts"}
@@ -61,7 +63,7 @@ jobs:
     - name: Install Alpine dependencies
       if: matrix.distro.name == 'alpine'
       run: |
-        apk --no-cache --update add bash gcc linux${{ matrix.distro.variant }} linux${{ matrix.distro.variant }}-dev make openssl coreutils patch
+        apk --no-cache --update add bash gcc linux-headers linux${{ matrix.distro.variant }} linux${{ matrix.distro.variant }}-dev make openssl coreutils patch
         make install
 
     - name: Install Arch Linux dependencies
@@ -126,12 +128,4 @@ jobs:
             [ -e "$depmod" ] && grep -r ^search "$depmod" || true
         done
 
-        if [ "${{ matrix.distro.name }}" = alpine ] && [ "${{ matrix.distro.variant }}" = "-lts" ]; then
-            if [ "${{ matrix.distro.tag }}" = "3.17" ]; then
-                ./run_test.sh --no-signing-tool
-            else
-                ./run_test.sh
-            fi
-        else
-            ./run_test.sh
-        fi
+        ./run_test.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
           - {name: "gentoo/stage3", tag: "latest"}
           - {name: "opensuse/tumbleweed", tag: "latest", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "opensuse/leap", tag: "15.6", variant: "-default", url: "registry.opensuse.org/"}
+          - {name: "ubuntu", tag: "25.04"}
           - {name: "ubuntu", tag: "24.10"}
           - {name: "ubuntu", tag: "24.04"}
           - {name: "ubuntu", tag: "22.04"}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,6 @@ jobs:
           - {name: "fedora", tag: "rawhide", url: "registry.fedoraproject.org/"}
           - {name: "fedora", tag: "42", url: "registry.fedoraproject.org/"}
           - {name: "fedora", tag: "41", url: "registry.fedoraproject.org/"}
-          - {name: "fedora", tag: "40", url: "registry.fedoraproject.org/"}
           - {name: "gentoo/stage3", tag: "latest"}
           - {name: "opensuse/tumbleweed", tag: "latest", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "opensuse/leap", tag: "15.6", variant: "-default", url: "registry.opensuse.org/"}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
           - {name: "debian", tag: "testing"}
           - {name: "debian", tag: "12"}
           - {name: "fedora", tag: "rawhide", url: "registry.fedoraproject.org/"}
+          - {name: "fedora", tag: "42", url: "registry.fedoraproject.org/"}
           - {name: "fedora", tag: "41", url: "registry.fedoraproject.org/"}
           - {name: "fedora", tag: "40", url: "registry.fedoraproject.org/"}
           - {name: "gentoo/stage3", tag: "latest"}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Install openSUSE leap dependencies
       if: contains(matrix.distro.name, 'opensuse')
       run: |
-        zypper --non-interactive install diffutils elfutils gcc kernel${{ matrix.distro.variant }} kernel${{ matrix.distro.variant }}-devel make openssl patch
+        zypper --non-interactive install diffutils elfutils gcc kernel${{ matrix.distro.variant }} kernel${{ matrix.distro.variant }}-devel make openssl patch zstd
         make install
 
     - name: Install Ubuntu dependencies


### PR DESCRIPTION
- Add Alpine 3.21 tests.
- Drop leftovers from EOL Alpine 3.17 removal.
- Add Fedora 42 tests.
- Drop Fedora 40 (EOL in May 2025).
- Add Ubuntu 25.04 tests.
- Fix errors:
  - Add `linux-headers` package to Alpine test installation.
  - Add `zstd` package to SLES and openSUSE test installations.