### PR TITLE
Do not use $ for describing framework.conf directives in the man page

### DIFF
--- a/dkms.8.in
+++ b/dkms.8.in
@@ -886,13 +886,13 @@ Additionally to
 .B /etc/dkms/framework.conf.d/*.conf
 will be loaded as well.
 .TP
-.B $dkms_tree, $source_tree, $install_tree, $tmp_location
+.B dkms_tree, source_tree, install_tree, tmp_location
 Control which folders DKMS uses for components and artifacts.
 .TP
-.B $verbose
+.B verbose
 Can be set to anything but a null value to enable verbose output of external commands executed in DKMS.
 .TP
-.B $symlink_modules
+.B symlink_modules
 Controls whether binary modules are copied to @MODDIR@ or if only symlinks are created there. Note that these variables can also
 be manipulated on the command line with
 .B \-\-dkmstree
@@ -904,26 +904,26 @@ and
 .B \-\-symlink-modules
 options.
 .TP
-.B $autoinstall_all_kernels
+.B autoinstall_all_kernels
 Used by the common postinst for DKMS modules. It controls if the build should be done for all installed kernels or only for the current and latest installed kernel. It has no command
 line equivalent.
 .TP
-.B $sign_file
+.B sign_file
 This is the path of the
 .B sign-file
 kernel binary that is used to sign the kernel modules. The variable
 .B $kernelver
 can be used in path to represent the target kernel version. The path for the binary depends on the distribution.
 .TP
-.B $mok_signing_key, $mok_certificate
+.B mok_signing_key, mok_certificate
 Location of the key and certificate files used for Secure boot. The variable
 .B $kernelver
 can be used in path to represent the target kernel version.
 
 NOTE: If any of the files specified by
-.B $mok_signing_key
+.B mok_signing_key
 and
-.B $mok_certificate
+.B mok_certificate
 are non-existant, dkms will re-create both files.
 
 .B mok_signing_key
@@ -931,13 +931,13 @@ can also be a "pkcs11:..." string for PKCS#11 engine, as long as the
 .B sign-file
 program supports it.
 .TP
-.B $modprobe_on_install
+.B modprobe_on_install
 Automatically load the built modules upon successful installation.
 .TP
-.B $parallel_jobs
+.B parallel_jobs
 Run no more than this number of jobs in parallel.
 .TP
-.B $compress_gzip_opts, $compress_xz_opts, $compress_zstd_opts
+.B compress_gzip_opts, compress_xz_opts, compress_zstd_opts
 Control how modules are compressed. By default, the highest available level of compression is used.
 .SH DKMS AUTOINSTALLER
 The DKMS autoinstaller service (which can be


### PR DESCRIPTION
Drop all the `$` when describing "directives" in the `man` page.