### PR TITLE
Fix text in framework.conf

### DIFF
--- a/dkms_framework.conf.in
+++ b/dkms_framework.conf.in
@@ -59,6 +59,6 @@
 # Command to run at the end of every DKMS transaction, for example after a new
 # kernel has been installed on the system and all modules have been succesfully
 # built and installed.
-# The command listed below is executed with the kernel version passed as a
-# parameter if set to any non null value:
+# The command listed is executed if set to any non null value. $kernelver can be
+# used in path to represent the target kernel version.
 # post_transaction=""


### PR DESCRIPTION
As part of https://github.com/dell/dkms/pull/522, we did a last minute change on the behavior of the `$kernel` variable, but the text in `framework.conf` was not updated accordingly.