### PR TITLE
Fix post_transaction when running dkms autoinstall via systemd unit

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -3437,7 +3437,7 @@ case "$action" in
         check_root && autoinstall
         ret=$?
         # Execute post_transaction command if set
-        if [[ $ret -eq 0 && -n "$post_transaction" ]]; then
+        if [[ $ret -eq 0 && -n "$post_transaction" && ${#installed_modules[@]} -gt 0 ]]; then
             execute_post_transaction
         fi
         exit $ret


### PR DESCRIPTION
When running `dkms autoinstall` through the `systemd` unit, even if there are no changes the `post_transaction` command is always executed.

In most cases this results in the `initrd` being recreated at every reboot, even without any module change.

Check that `dkms autoinstall` has actually installed any module before calling the `post_transaction` command.