### PR TITLE
Add per-module conditionals

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,4 +128,5 @@ jobs:
             [ -e "$depmod" ] && grep -r ^search "$depmod" || true
         done
 
+        # Run all tests
         ./run_test.sh

--- a/dkms.8.in
+++ b/dkms.8.in
@@ -802,6 +802,19 @@ For example, if you set it as ="CONFIG_PCI !CONFIG_PREEMPT_RT", your module
 would only be built for kernels that have PCI enabled, but the RT patchset
 disabled.
 .TP
+.B BUILD_EXCLUSIVE_KERNEL[#]=, BUILD_EXCLUSIVE_KERNEL_MIN[#]=, BUILD_EXCLUSIVE_KERNEL_MAX[#]=, BUILD_EXCLUSIVE_ARCH[#]=, BUILD_EXCLUSIVE_CONFIG[#]=
+These optional per-module directives function identically to their global counterparts
+but apply only to the specific module at the given index. They allow you to specify
+different BUILD_EXCLUSIVE constraints for each module in a multi-module package.
+The global BUILD_EXCLUSIVE directives are still checked for backward compatibility,
+and if any module fails either the global or its specific per-module constraints,
+the build will be excluded.
+
+For example, if you have two modules in your package:
+.B BUILD_EXCLUSIVE_KERNEL[0]="^5\..*"
+.B BUILD_EXCLUSIVE_KERNEL[1]="^6\..*"
+Module 0 would only be built for kernel 5.x, while module 1 would only be built for kernel 6.x.
+.TP
 .B POST_ADD=
 The name of the script to be run after an
 .B add

--- a/dkms.in
+++ b/dkms.in
@@ -806,19 +806,57 @@ read_conf() {
 
     # Set build_exclude
     [[ $obsolete_by && ! $BUILD_EXCLUSIVE_KERNEL_MAX ]] && BUILD_EXCLUSIVE_KERNEL_MAX=$obsolete_by
-    [[ $BUILD_EXCLUSIVE_KERNEL && ! $1 =~ $BUILD_EXCLUSIVE_KERNEL ]] && build_exclude="yes"
-    [[ $BUILD_EXCLUSIVE_KERNEL_MIN && "$(VER "$1")" < "$(VER "$BUILD_EXCLUSIVE_KERNEL_MIN")" ]] && build_exclude="yes"
-    [[ $BUILD_EXCLUSIVE_KERNEL_MAX && "$(VER "$1")" > "$(VER "$BUILD_EXCLUSIVE_KERNEL_MAX")" ]] && build_exclude="yes"
-    [[ $BUILD_EXCLUSIVE_ARCH && ! $2 =~ $BUILD_EXCLUSIVE_ARCH ]] && build_exclude="yes"
-    if [[ $BUILD_EXCLUSIVE_CONFIG && -e "${kernel_config}" ]]; then
-        local kconf
-        for kconf in $BUILD_EXCLUSIVE_CONFIG ; do
-            case "$kconf" in
-                !*) grep -q "^${kconf#!}=[ym]" "${kernel_config}" && build_exclude="yes" ;;
-                *)  grep -q "^${kconf}=[ym]" "${kernel_config}" || build_exclude="yes" ;;
-            esac
-        done
-    fi
+
+    # Function to check BUILD_EXCLUSIVE conditions for a specific module
+    check_build_exclusive_for_module() {
+        local module_index="$1"
+        local kernel_version="$2"
+        local arch="$3"
+
+        # Check global BUILD_EXCLUSIVE directives (backward compatibility)
+        [[ $BUILD_EXCLUSIVE_KERNEL && ! $kernel_version =~ $BUILD_EXCLUSIVE_KERNEL ]] && return 1
+        [[ $BUILD_EXCLUSIVE_KERNEL_MIN && "$(VER "$kernel_version")" < "$(VER "$BUILD_EXCLUSIVE_KERNEL_MIN")" ]] && return 1
+        [[ $BUILD_EXCLUSIVE_KERNEL_MAX && "$(VER "$kernel_version")" > "$(VER "$BUILD_EXCLUSIVE_KERNEL_MAX")" ]] && return 1
+        [[ $BUILD_EXCLUSIVE_ARCH && ! $arch =~ $BUILD_EXCLUSIVE_ARCH ]] && return 1
+
+        # Check per-module BUILD_EXCLUSIVE directives
+        [[ ${BUILD_EXCLUSIVE_KERNEL[$module_index]} && ! $kernel_version =~ ${BUILD_EXCLUSIVE_KERNEL[$module_index]} ]] && return 1
+        [[ ${BUILD_EXCLUSIVE_KERNEL_MIN[$module_index]} && "$(VER "$kernel_version")" < "$(VER "${BUILD_EXCLUSIVE_KERNEL_MIN[$module_index]}")" ]] && return 1
+        [[ ${BUILD_EXCLUSIVE_KERNEL_MAX[$module_index]} && "$(VER "$kernel_version")" > "$(VER "${BUILD_EXCLUSIVE_KERNEL_MAX[$module_index]}")" ]] && return 1
+        [[ ${BUILD_EXCLUSIVE_ARCH[$module_index]} && ! $arch =~ ${BUILD_EXCLUSIVE_ARCH[$module_index]} ]] && return 1
+
+        # Check BUILD_EXCLUSIVE_CONFIG (both global and per-module)
+        if [[ $BUILD_EXCLUSIVE_CONFIG && -e "${kernel_config}" ]]; then
+            local kconf
+            for kconf in $BUILD_EXCLUSIVE_CONFIG ; do
+                case "$kconf" in
+                    !*) grep -q "^${kconf#!}=[ym]" "${kernel_config}" && return 1 ;;
+                    *)  grep -q "^${kconf}=[ym]" "${kernel_config}" || return 1 ;;
+                esac
+            done
+        fi
+
+        if [[ ${BUILD_EXCLUSIVE_CONFIG[$module_index]} && -e "${kernel_config}" ]]; then
+            local kconf
+            for kconf in ${BUILD_EXCLUSIVE_CONFIG[$module_index]} ; do
+                case "$kconf" in
+                    !*) grep -q "^${kconf#!}=[ym]" "${kernel_config}" && return 1 ;;
+                    *)  grep -q "^${kconf}=[ym]" "${kernel_config}" || return 1 ;;
+                esac
+            done
+        fi
+
+        return 0
+    }
+
+    # Check if any module should be excluded from build
+    build_exclude=""
+    for ((index=0; index < num_modules; index++)); do
+        if ! check_build_exclusive_for_module "$index" "$1" "$2"; then
+            build_exclude="yes"
+            break
+        fi
+    done
 
     # Helper function to check yes/no values
     check_yes_no_value() {

--- a/run_test.sh
+++ b/run_test.sh
@@ -52,6 +52,10 @@ TEST_MODULES=(
     "dkms_deprecated_test"
     "dkms_build_exclusive_test"
     "dkms_build_exclusive_dependencies_test"
+    "dkms_per_module_config_test"
+    "dkms_per_module_kernel_version_test"
+    "dkms_per_module_config_exclusive_test"
+    "dkms_per_module_mixed_test"
 )
 TEST_TMPDIRS=(
     "/usr/src/dkms_test-1.0"
@@ -81,6 +85,10 @@ TEST_TMPDIRS=(
     "/usr/src/dkms_deprecated_test-1.0"
     "/usr/src/dkms_build_exclusive_test-1.0"
     "/usr/src/dkms_build_exclusive_dependencies_test-1.0"
+    "/usr/src/dkms_per_module_config_test-1.0"
+    "/usr/src/dkms_per_module_kernel_version_test-1.0"
+    "/usr/src/dkms_per_module_config_exclusive_test-1.0"
+    "/usr/src/dkms_per_module_mixed_test-1.0"
     "${tmpdir}/dkms_test_dir_${KERNEL_VER}/"
 )
 TEST_TMPFILES=(
@@ -3670,7 +3678,7 @@ fi  # autoinstall tests
 if [[ ! $only || $only = exclusive ]]; then
 
 ############################################################################
-echo '*** Running tests with BUILD_EXCLUSIVE_* modules'
+echo '*** Testing modules with BUILD_EXCLUSIVE_* directives'
 ############################################################################
 
 set_signing_message "dkms_test" "1.0"
@@ -3865,6 +3873,94 @@ run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
 EOF
 
 remove_module_source_tree /usr/src/dkms_build_exclusive_test-1.0
+
+############################################################################
+echo '*** Testing per-module BUILD_EXCLUSIVE directives'
+############################################################################
+
+echo 'Adding per-module config test module'
+run_with_expected_output dkms add test/dkms_per_module_config_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_per_module_config_test/1.0/source -> /usr/src/dkms_per_module_config_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_per_module_config_test-1.0
+run_status_with_expected_output 'dkms_per_module_config_test' << EOF
+dkms_per_module_config_test/1.0: added
+EOF
+
+echo 'Testing per-module config test module build (should be excluded due to per-module restrictions)'
+run_with_expected_error 77 dkms build -k "${KERNEL_VER}" -m dkms_per_module_config_test -v 1.0 << EOF
+Warning: The /var/lib/dkms/dkms_per_module_config_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+for module dkms_per_module_config_test/1.0 includes a BUILD_EXCLUSIVE directive
+which does not match this kernel/arch/config.
+This indicates that it should not be built.
+EOF
+run_status_with_expected_output 'dkms_per_module_config_test' << EOF
+dkms_per_module_config_test/1.0: added
+EOF
+
+echo 'Removing per-module config test module'
+run_with_expected_output dkms remove --all -m dkms_per_module_config_test -v 1.0 << EOF
+Deleting module dkms_per_module_config_test/1.0 completely from the DKMS tree.
+EOF
+run_status_with_expected_output 'dkms_per_module_config_test' << EOF
+EOF
+remove_module_source_tree /usr/src/dkms_per_module_config_test-1.0
+
+echo 'Adding per-module kernel version test module'
+run_with_expected_output dkms add test/dkms_per_module_kernel_version_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_per_module_kernel_version_test/1.0/source -> /usr/src/dkms_per_module_kernel_version_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_per_module_kernel_version_test-1.0
+run_status_with_expected_output 'dkms_per_module_kernel_version_test' << EOF
+dkms_per_module_kernel_version_test/1.0: added
+EOF
+
+echo 'Testing per-module kernel version test module build (should be excluded due to kernel version restrictions)'
+run_with_expected_error 77 dkms build -k "${KERNEL_VER}" -m dkms_per_module_kernel_version_test -v 1.0 << EOF
+Warning: The /var/lib/dkms/dkms_per_module_kernel_version_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+for module dkms_per_module_kernel_version_test/1.0 includes a BUILD_EXCLUSIVE directive
+which does not match this kernel/arch/config.
+This indicates that it should not be built.
+EOF
+run_status_with_expected_output 'dkms_per_module_kernel_version_test' << EOF
+dkms_per_module_kernel_version_test/1.0: added
+EOF
+
+echo 'Removing per-module kernel version test module'
+run_with_expected_output dkms remove --all -m dkms_per_module_kernel_version_test -v 1.0 << EOF
+Deleting module dkms_per_module_kernel_version_test/1.0 completely from the DKMS tree.
+EOF
+run_status_with_expected_output 'dkms_per_module_kernel_version_test' << EOF
+EOF
+remove_module_source_tree /usr/src/dkms_per_module_kernel_version_test-1.0
+
+echo 'Adding per-module config exclusive test module'
+run_with_expected_output dkms add test/dkms_per_module_config_exclusive_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_per_module_config_exclusive_test/1.0/source -> /usr/src/dkms_per_module_config_exclusive_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_per_module_config_exclusive_test-1.0
+run_status_with_expected_output 'dkms_per_module_config_exclusive_test' << EOF
+dkms_per_module_config_exclusive_test/1.0: added
+EOF
+
+echo 'Testing per-module config exclusive test module build (should be excluded due to missing config)'
+run_with_expected_error 77 dkms build -k "${KERNEL_VER}" -m dkms_per_module_config_exclusive_test -v 1.0 << EOF
+Warning: The /var/lib/dkms/dkms_per_module_config_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+for module dkms_per_module_config_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
+which does not match this kernel/arch/config.
+This indicates that it should not be built.
+EOF
+run_status_with_expected_output 'dkms_per_module_config_exclusive_test' << EOF
+dkms_per_module_config_exclusive_test/1.0: added
+EOF
+
+echo 'Removing per-module config exclusive test module'
+run_with_expected_output dkms remove --all -m dkms_per_module_config_exclusive_test -v 1.0 << EOF
+Deleting module dkms_per_module_config_exclusive_test/1.0 completely from the DKMS tree.
+EOF
+run_status_with_expected_output 'dkms_per_module_config_exclusive_test' << EOF
+EOF
+remove_module_source_tree /usr/src/dkms_per_module_config_exclusive_test-1.0
 
 echo 'Checking that the environment is clean again'
 check_no_dkms_test

--- a/test/dkms_per_module_config_exclusive_test-1.0/Makefile
+++ b/test/dkms_per_module_config_exclusive_test-1.0/Makefile
@@ -1,0 +1,1 @@
+obj-m += dkms_per_module_config_exclusive_test_mod1.o dkms_per_module_config_exclusive_test_mod2.o

--- a/test/dkms_per_module_config_exclusive_test-1.0/dkms.conf
+++ b/test/dkms_per_module_config_exclusive_test-1.0/dkms.conf
@@ -1,0 +1,15 @@
+PACKAGE_NAME="dkms_per_module_config_exclusive_test"
+PACKAGE_VERSION="1.0"
+
+BUILT_MODULE_NAME[0]="dkms_per_module_config_exclusive_test_mod1"
+BUILT_MODULE_NAME[1]="dkms_per_module_config_exclusive_test_mod2"
+
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+DEST_MODULE_LOCATION[1]="/updates/dkms"
+
+# Requires CONFIG_MODULES to be enabled and CONFIG_NONEXISTENT_CONFIG to be absent (should always match):
+BUILD_EXCLUSIVE_CONFIG[0]="CONFIG_MODULES !CONFIG_NONEXISTENT_CONFIG"
+# Requires CONFIG_NONEXISTENT_CONFIG to be enabled and CONFIG_MODULES to be abset (should never match):
+BUILD_EXCLUSIVE_CONFIG[1]="!CONFIG_MODULES CONFIG_NONEXISTENT_CONFIG"
+
+AUTOINSTALL="yes"

--- a/test/dkms_per_module_config_exclusive_test-1.0/dkms_per_module_config_exclusive_test_mod1.c
+++ b/test/dkms_per_module_config_exclusive_test-1.0/dkms_per_module_config_exclusive_test_mod1.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_exclusive_test_mod1_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_exclusive_test_mod1: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_exclusive_test_mod1_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_exclusive_test_mod1: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_exclusive_test_mod1_init);
+module_exit(dkms_per_module_config_exclusive_test_mod1_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config exclusive test module 1");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_config_exclusive_test-1.0/dkms_per_module_config_exclusive_test_mod2.c
+++ b/test/dkms_per_module_config_exclusive_test-1.0/dkms_per_module_config_exclusive_test_mod2.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_exclusive_test_mod2_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_exclusive_test_mod2: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_exclusive_test_mod2_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_exclusive_test_mod2: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_exclusive_test_mod2_init);
+module_exit(dkms_per_module_config_exclusive_test_mod2_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config exclusive test module 2");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_config_test-1.0/Makefile
+++ b/test/dkms_per_module_config_test-1.0/Makefile
@@ -1,0 +1,1 @@
+obj-m += dkms_per_module_config_test_mod1.o dkms_per_module_config_test_mod2.o dkms_per_module_config_test_mod3.o

--- a/test/dkms_per_module_config_test-1.0/dkms.conf
+++ b/test/dkms_per_module_config_test-1.0/dkms.conf
@@ -1,0 +1,18 @@
+PACKAGE_NAME="dkms_per_module_config_test"
+PACKAGE_VERSION="1.0"
+
+BUILT_MODULE_NAME[0]="dkms_per_module_config_test_mod1"
+BUILT_MODULE_NAME[1]="dkms_per_module_config_test_mod2"
+BUILT_MODULE_NAME[2]="dkms_per_module_config_test_mod3"
+
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+DEST_MODULE_LOCATION[1]="/updates/dkms"
+DEST_MODULE_LOCATION[2]="/updates/dkms"
+
+# Build only for kernel starting with 99 (should never match):
+BUILD_EXCLUSIVE_KERNEL[0]="^99\..*"
+# Build for any kernel (should always match) but only for architecture "none" (should never match):
+BUILD_EXCLUSIVE_KERNEL[1]=".*"
+BUILD_EXCLUSIVE_ARCH[1]="none"
+
+AUTOINSTALL="yes"

--- a/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod1.c
+++ b/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod1.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_test_mod1_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod1: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_test_mod1_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod1: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_test_mod1_init);
+module_exit(dkms_per_module_config_test_mod1_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config test module 1");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod2.c
+++ b/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod2.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_test_mod2_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod2: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_test_mod2_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod2: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_test_mod2_init);
+module_exit(dkms_per_module_config_test_mod2_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config test module 2");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod3.c
+++ b/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod3.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_test_mod3_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod3: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_test_mod3_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod3: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_test_mod3_init);
+module_exit(dkms_per_module_config_test_mod3_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config test module 3");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_kernel_version_test-1.0/Makefile
+++ b/test/dkms_per_module_kernel_version_test-1.0/Makefile
@@ -1,0 +1,1 @@
+obj-m += dkms_per_module_kernel_version_test_old.o dkms_per_module_kernel_version_test_new.o

--- a/test/dkms_per_module_kernel_version_test-1.0/dkms.conf
+++ b/test/dkms_per_module_kernel_version_test-1.0/dkms.conf
@@ -1,0 +1,15 @@
+PACKAGE_NAME="dkms_per_module_kernel_version_test"
+PACKAGE_VERSION="1.0"
+
+BUILT_MODULE_NAME[0]="dkms_per_module_kernel_version_test_old"
+BUILT_MODULE_NAME[1]="dkms_per_module_kernel_version_test_new"
+
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+DEST_MODULE_LOCATION[1]="/updates/dkms"
+
+# Build only for kernels < 5.0 (should never match):
+BUILD_EXCLUSIVE_KERNEL_MAX[0]="4.99"
+# Build only for kernels >= 5.0 (should always match):
+BUILD_EXCLUSIVE_KERNEL_MIN[1]="5.0"
+
+AUTOINSTALL="yes"

--- a/test/dkms_per_module_kernel_version_test-1.0/dkms_per_module_kernel_version_test_new.c
+++ b/test/dkms_per_module_kernel_version_test-1.0/dkms_per_module_kernel_version_test_new.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_kernel_version_test_new_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_kernel_version_test_new: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_kernel_version_test_new_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_kernel_version_test_new: module unloaded\n");
+}
+
+module_init(dkms_per_module_kernel_version_test_new_init);
+module_exit(dkms_per_module_kernel_version_test_new_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module kernel version test - new kernel module");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_kernel_version_test-1.0/dkms_per_module_kernel_version_test_old.c
+++ b/test/dkms_per_module_kernel_version_test-1.0/dkms_per_module_kernel_version_test_old.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_kernel_version_test_old_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_kernel_version_test_old: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_kernel_version_test_old_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_kernel_version_test_old: module unloaded\n");
+}
+
+module_init(dkms_per_module_kernel_version_test_old_init);
+module_exit(dkms_per_module_kernel_version_test_old_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module kernel version test - old kernel module");
+MODULE_VERSION("1.0");


### PR DESCRIPTION
Add per-module `BUILD_EXCLUSIVE_*` directives in DKMS.

* Backward compatibility: global `BUILD_EXCLUSIVE` directives still work as before.
* Per-module support: new array-based directives `BUILD_EXCLUSIVE_KERNEL[#]`, `BUILD_EXCLUSIVE_KERNEL_MIN[#]`, `BUILD_EXCLUSIVE_KERNEL_MAX[#]`, `BUILD_EXCLUSIVE_ARCH[#]`, and `BUILD_EXCLUSIVE_CONFIG[#]`.
* Combined logic: both global and per-module directives are checked, and if any module fails either set of constraints, the build is excluded.

Implements https://github.com/dell/dkms/issues/471.