### PR TITLE
fix: return success when do redhat_kernel_install.d.in

### DIFF
--- a/redhat_kernel_install.d.in
+++ b/redhat_kernel_install.d.in
@@ -3,15 +3,13 @@
 COMMAND=$1
 KERNEL_VERSION=$2
 
-res=0
 case "$COMMAND" in
     add)
         dkms kernel_postinst --kernelver "$KERNEL_VERSION"
-        res=$?
         ;;
     remove)
         dkms kernel_prerm --kernelver "$KERNEL_VERSION"
-        res=$?
         ;;
 esac
-exit $res
+
+exit 0


### PR DESCRIPTION
Commit 703aa45 ("redhat_kernel_install.d.in: make shellcheck happy") will cause redhat_kernel_install.d.in returned error when dkms cmd was failed. In that case, the POSTTRANS scriptlet of kernel install will failed unexpectedly. Fix it.