### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,14 +15,14 @@ jobs:
         distro:
           - {name: "almalinux", tag: "9"}
           - {name: "almalinux", tag: "8"}
+          - {name: "alpine", tag: "3.22", variant: "-lts"}
+          - {name: "alpine", tag: "3.22", variant: "-virt"}
           - {name: "alpine", tag: "3.21", variant: "-lts"}
           - {name: "alpine", tag: "3.21", variant: "-virt"}
           - {name: "alpine", tag: "3.20", variant: "-lts"}
           - {name: "alpine", tag: "3.20", variant: "-virt"}
           - {name: "alpine", tag: "3.19", variant: "-lts"}
           - {name: "alpine", tag: "3.19", variant: "-virt"}
-          - {name: "alpine", tag: "3.18", variant: "-lts"}
-          - {name: "alpine", tag: "3.18", variant: "-virt"}
           - {name: "archlinux", tag: "latest"}
           - {name: "archlinux", tag: "latest", variant: "-lts"}
           - {name: "archlinux", tag: "latest", variant: "-zen"}
@@ -30,6 +30,7 @@ jobs:
           - {name: "centos", tag: "stream9", url: "quay.io/centos/"}
           - {name: "debian", tag: "testing"}
           - {name: "debian", tag: "12"}
+          - {name: "debian", tag: "testing"}
           - {name: "fedora", tag: "rawhide", url: "registry.fedoraproject.org/"}
           - {name: "fedora", tag: "42", url: "registry.fedoraproject.org/"}
           - {name: "fedora", tag: "41", url: "registry.fedoraproject.org/"}
@@ -37,10 +38,8 @@ jobs:
           - {name: "opensuse/tumbleweed", tag: "latest", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "opensuse/leap", tag: "15.6", variant: "-default", url: "registry.opensuse.org/"}
           - {name: "ubuntu", tag: "25.04"}
-          - {name: "ubuntu", tag: "24.10"}
           - {name: "ubuntu", tag: "24.04"}
           - {name: "ubuntu", tag: "22.04"}
-          - {name: "ubuntu", tag: "20.04"}
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.distro.url }}${{ matrix.distro.name }}:${{ matrix.distro.tag }}

--- a/dkms.in
+++ b/dkms.in
@@ -1020,7 +1020,7 @@ check_version_sanity()
         return 0
     fi
     local dkms_module
-    dkms_module=$(compressed_or_uncompressed "$dkms_tree/$module/$module_version/$1/$2/module/" "${4}")
+    dkms_module=$(compressed_or_uncompressed "$dkms_tree/$module/$module_version/$1/$2/module" "${4}")
 
     local cmp_res
     cmp_res="$(compare_module_version "${kernels_module}" "${dkms_module}")"

--- a/dkms.in
+++ b/dkms.in
@@ -1472,7 +1472,6 @@ do_build()
     mkdir -p "$kernelver_dir"
     local -r tmp_base_dir=$(mktemp_or_die -d "$kernelver_dir/.tmp_${arch}_XXXXXX")
     mkdir -p "$tmp_base_dir/log"
-    [[ $kernel_config ]] && cp -f "$kernel_config" "$tmp_base_dir/log/"
 
     # Save a copy of the new module
     mkdir -p "$tmp_base_dir/module"


### PR DESCRIPTION
- Update list of distributions for tests:
  - Add Alpine Linux version 3.22.
  - Drop Alpine Linux version 3.18 (EOL).
  - Add Debian testing (13 not yet available).
  - Drop Ubuntu 24.10 (EOL).
  - Drop Ubuntu 20.04 (EOL).
 - Import Debian patches:
   - Drop duplicate slash from path.
   - Do not store an unused copy of the kernel configuration.