### PR TITLE
dkms: Source copy changes #538

### DIFF
--- a/dkms.in
+++ b/dkms.in
@@ -2429,7 +2429,7 @@ make_tarball()
         echo ""
         echo "Marking $source_dir for archiving..."
         mkdir -p "$temp_dir_name/dkms_source_tree"
-        cp -frT "$source_dir/" "$temp_dir_name/dkms_source_tree"
+        cp -fprT "$source_dir/" "$temp_dir_name/dkms_source_tree"
     fi
 
     # shellcheck disable=SC1083
@@ -2750,7 +2750,7 @@ add_source_tree() {
             ;;
     esac
     mkdir -p "$source_tree/$module-$module_version"
-    cp -frT "$from/" "$source_tree/$module-$module_version"
+    cp -fprT "$from/" "$source_tree/$module-$module_version"
 }
 
 # This code used to be in dkms_autoinstaller.


### PR DESCRIPTION
The "Use cp's -T option instead of wildcards when copying source directory" commit implements #538 to copy dot-files. Since dkms is already using the `-a` option, I thought it would be fine to use the `-T` option supported by GNU coreutils cp and BusyBox cp.

The "Preserve timestamps, file modes, and ownership when copying source directory" additionally uses cp's `-p` option, mostly to preserve the timestamps. It may help in cases where the source directory contains generated sources that should not need rebuilding.