### PR TITLE
sparse arrays and a few more fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ install-debian: install
 	install -D -m 0755 debian_kernel_postinst.d $(DESTDIR)$(KCONF)/header_postinst.d/dkms
 	install -D -m 0755 debian_kernel_preinst.d $(DESTDIR)$(KCONF)/preinst.d/dkms
 	install -D -m 0755 debian_kernel_prerm.d $(DESTDIR)$(KCONF)/prerm.d/dkms
-	install -D -m 0644 dkms.service $(DESTDIR)$(SYSTEMD)/dkms.service
 
 install-doc:
 	$(if $(strip $(DOC)),$(error Setting DOCDIR is not supported))

--- a/dkms.in
+++ b/dkms.in
@@ -149,6 +149,11 @@ on_exit()
 unset make_tarball_rm_temp_dir_name load_tarball_rm_temp_dir_name
 trap on_exit EXIT
 
+CP()
+{
+    cp --reflink=auto "$@"
+}
+
 # Run a command that we may or may not want to be detailed about.
 invoke_command()
 {
@@ -1467,7 +1472,7 @@ do_build()
 
     # Set up temporary build directory for build
     rm -rf "${build_dir:?}"
-    cp -a "$source_dir/" "$build_dir"
+    CP -a "$source_dir/" "$build_dir"
 
     echo "DKMS (@RELEASE_STRING@) make.log for $module/$module_version for kernel $kernelver ($arch)" >> "$build_log"
     date >> "$build_log"
@@ -1515,7 +1520,7 @@ do_build()
     # Save a copy of the new module
     mkdir -p "$tmp_base_dir/module"
     if [[ -f "$build_dir/Module.symvers" ]] ; then
-        cp -f "$build_dir/Module.symvers" "$tmp_base_dir/module/Module.symvers"
+        CP -f "$build_dir/Module.symvers" "$tmp_base_dir/module/Module.symvers"
     fi
     for ((count=0; count < num_modules; count++)); do
         local the_module
@@ -1557,9 +1562,9 @@ do_build()
             zstd $compress_zstd_opts -f "$built_module" || compressed_module=""
         fi
         if [[ $compressed_module ]]; then
-            cp -f "$compressed_module" "$tmp_base_dir/module/${dest_module_name[$count]}$module_suffix"
+            CP -f "$compressed_module" "$tmp_base_dir/module/${dest_module_name[$count]}$module_suffix"
         else
-            cp -f "$built_module" "$tmp_base_dir/module/${dest_module_name[$count]}$module_uncompressed_suffix"
+            CP -f "$built_module" "$tmp_base_dir/module/${dest_module_name[$count]}$module_uncompressed_suffix"
         fi
     done
 
@@ -1772,7 +1777,7 @@ do_install()
         dest_name=${toinstall##*/}
         echo "Installing $dest_dir/$dest_name"
         mkdir -p "$dest_dir"
-        cp -f $symlink "$toinstall" "$dest_dir/$dest_name" || die 6 "Copying '$toinstall' failed"
+        CP -f $symlink "$toinstall" "$dest_dir/$dest_name" || die 6 "Copying '$toinstall' failed"
         any_module_installed=1
 
     done
@@ -2446,7 +2451,7 @@ make_tarball()
             kernel_version_list="${kernel_version_list}-kernel${kernelver[$i]}-${arch[$i]}"
         fi
         mkdir -p "$temp_module_dir"
-        cp -rf "$intree_module_dir" "$temp_module_dir"
+        CP -rf "$intree_module_dir" "$temp_module_dir"
     done
     fi
 
@@ -2463,12 +2468,12 @@ make_tarball()
         echo "$module" > "$binary_only_dir/PACKAGE_NAME"
         echo "$module_version" > "$binary_only_dir/PACKAGE_VERSION"
         [[ ! $conf ]] && conf="$source_dir/dkms.conf"
-        cp -f "$conf" "$binary_only_dir/" 2>/dev/null
+        CP -f "$conf" "$binary_only_dir/" 2>/dev/null
     else
         echo ""
         echo "Marking $source_dir for archiving..."
         mkdir -p "$temp_dir_name/dkms_source_tree"
-        cp -fprT "$source_dir/" "$temp_dir_name/dkms_source_tree"
+        CP -fprT "$source_dir/" "$temp_dir_name/dkms_source_tree"
     fi
 
     # shellcheck disable=SC1083
@@ -2590,7 +2595,7 @@ load_tarball()
                 echo "Creating $source_dir"
                 mkdir -p "$source_dir"
                 echo "Copying dkms.conf to $source_dir ..."
-                cp -rf "$temp_dir_name/dkms_binaries_only/dkms.conf" "$source_dir"
+                CP -rf "$temp_dir_name/dkms_binaries_only/dkms.conf" "$source_dir"
             fi
             ;;
     esac
@@ -2612,7 +2617,7 @@ load_tarball()
             echo "Loading $dkms_dir_location..."
             rm -rf "${dkms_dir_location:?}"
             mkdir -p "$dkms_dir_location"
-            cp -rf "$directory/"* "$dkms_dir_location/"
+            CP -rf "$directory/"* "$dkms_dir_location/"
         fi
     done
 
@@ -2789,7 +2794,7 @@ add_source_tree() {
             ;;
     esac
     mkdir -p "$source_tree/$module-$module_version"
-    cp -fprT "$from/" "$source_tree/$module-$module_version"
+    CP -fprT "$from/" "$source_tree/$module-$module_version"
 }
 
 # This code used to be in dkms_autoinstaller.

--- a/dkms.in
+++ b/dkms.in
@@ -673,15 +673,18 @@ read_conf() {
     fi
 
     # Determine number of modules
+    # The arrays are possibly sparse, so use the maximum index instead of the array length
     local s
-    num_modules=0
+    local max_index
+    max_index=-1
     # shellcheck disable=SC2153
-    for s in ${#BUILT_MODULE_NAME[@]} \
-        ${#BUILT_MODULE_LOCATION[@]} \
-        ${#DEST_MODULE_NAME[@]} \
-        ${#DEST_MODULE_LOCATION[@]}; do
-        ((s > num_modules)) && num_modules=$s
+    for s in "${!BUILT_MODULE_NAME[@]}" \
+        "${!BUILT_MODULE_LOCATION[@]}" \
+        "${!DEST_MODULE_NAME[@]}" \
+        "${!DEST_MODULE_LOCATION[@]}"; do
+        ((s > max_index)) && max_index=$s
     done
+    num_modules=$((max_index + 1))
 
     # Set module naming/location arrays
     local index

--- a/dkms.in
+++ b/dkms.in
@@ -739,14 +739,12 @@ read_conf() {
         # Override location for specific distributions
         dest_module_location[index]="$(override_dest_module_location "${dest_module_location[index]}")"
 
-        # Fail if no DEST_MODULE_LOCATION
-        if [[ ! ${DEST_MODULE_LOCATION[$index]} ]]; then
-            echo "dkms.conf: Error! No 'DEST_MODULE_LOCATION' directive specified for record #$index.">&2
-            return_value=1
-        fi
-
         # Fail if bad DEST_MODULE_LOCATION
         case ${DEST_MODULE_LOCATION[$index]} in
+            "")
+                echo "dkms.conf: Error! No 'DEST_MODULE_LOCATION' directive specified for record #$index.">&2
+                return_value=1
+                ;;
             /kernel*)
                 ;;
             /updates*)
@@ -754,9 +752,9 @@ read_conf() {
             /extra*)
                 ;;
             *)
-            echo "dkms.conf: Error! Directive 'DEST_MODULE_LOCATION' does not begin with">&2
-            echo "'/kernel', '/updates', or '/extra' in record #$index.">&2
-            return_value=1
+                echo "dkms.conf: Error! Directive 'DEST_MODULE_LOCATION' does not begin with">&2
+                echo "'/kernel', '/updates', or '/extra' in record #$index.">&2
+                return_value=1
             ;;
         esac
     done

--- a/run_test.sh
+++ b/run_test.sh
@@ -55,40 +55,8 @@ TEST_MODULES=(
     "dkms_per_module_config_test"
     "dkms_per_module_kernel_version_test"
     "dkms_per_module_config_exclusive_test"
-    "dkms_per_module_mixed_test"
 )
 TEST_TMPDIRS=(
-    "/usr/src/dkms_test-1.0"
-    "/usr/src/dkms_test-2.0"
-    "/usr/src/dkms_dependencies_test-1.0"
-    "/usr/src/dkms_dependencies_rebuild_test-1.0"
-    "/usr/src/dkms_circular_dependencies_test-1.0"
-    "/usr/src/dkms_replace_test-2.0"
-    "/usr/src/dkms_noautoinstall_test-1.0"
-    "/usr/src/dkms_failing_test-1.0"
-    "/usr/src/dkms_failing_dependencies_test-1.0"
-    "/usr/src/dkms_multiver_test-1.0"
-    "/usr/src/dkms_multiver_test-2.0"
-    "/usr/src/dkms_nover_test-1.0"
-    "/usr/src/dkms_emptyver_test-1.0"
-    "/usr/src/dkms_nover_update_test-1.0"
-    "/usr/src/dkms_nover_update_test-2.0"
-    "/usr/src/dkms_nover_update_test-3.0"
-    "/usr/src/dkms_conf_test-1.0"
-    "/usr/src/dkms_duplicate_test-1.0"
-    "/usr/src/dkms_duplicate_built_test-1.0"
-    "/usr/src/dkms_duplicate_dest_test-1.0"
-    "/usr/src/dkms_patches_test-1.0"
-    "/usr/src/dkms_scripts_test-1.0"
-    "/usr/src/dkms_noisy_test-1.0"
-    "/usr/src/dkms_crlf_test-1.0"
-    "/usr/src/dkms_deprecated_test-1.0"
-    "/usr/src/dkms_build_exclusive_test-1.0"
-    "/usr/src/dkms_build_exclusive_dependencies_test-1.0"
-    "/usr/src/dkms_per_module_config_test-1.0"
-    "/usr/src/dkms_per_module_kernel_version_test-1.0"
-    "/usr/src/dkms_per_module_config_exclusive_test-1.0"
-    "/usr/src/dkms_per_module_mixed_test-1.0"
     "${tmpdir}/dkms_test_dir_${KERNEL_VER}/"
 )
 TEST_TMPFILES=(
@@ -126,11 +94,14 @@ dkms_status_grep_dkms_module() {
 
 clean_dkms_env() {
     local found_module
+    local module
+    local version
+    local dir
+    local file
 
     for module in "${TEST_MODULES[@]}"; do
         found_module=$(dkms_status_grep_dkms_module "${module}")
         if [[ $found_module ]] ; then
-            local version
             for version in 1.0 2.0 3.0; do
                 [[ ! -d "/var/lib/dkms/${module}/${version}" ]] || dkms remove "${module}/${version}" >/dev/null || true
             done
@@ -138,6 +109,9 @@ clean_dkms_env() {
         rm -rf "/var/lib/dkms/${module}/"
         rm -f "/lib/modules/${KERNEL_VER}/${expected_dest_loc}/${module}.ko${mod_compression_ext}"
         rm -f "/lib/modules/${KERNEL_VER}/kernel/extra/${module}.ko${mod_compression_ext}"
+        for version in 1.0 2.0 3.0; do
+            rm -rf "/usr/src/${module}-${version}"
+        done
     done
     for dir in "${TEST_TMPDIRS[@]}"; do
         rm -rf "$dir"

--- a/run_test.sh
+++ b/run_test.sh
@@ -3031,6 +3031,22 @@ remove_module_source_tree /usr/src/dkms_conf_test-1.0
 
 # --------------------------------------------------------------------------
 
+echo 'Testing dkms.conf with sparse BUILT_MODULE_NAME[] array (expected error)'
+run_with_expected_error 8 dkms add test/dkms_conf_test_sparse_arrays << EOF
+dkms.conf: Error! No 'BUILT_MODULE_NAME' directive specified for record #0.
+dkms.conf: Error! No 'DEST_MODULE_LOCATION' directive specified for record #0.
+dkms.conf: Error! No 'BUILT_MODULE_NAME' directive specified for record #2.
+dkms.conf: Error! No 'DEST_MODULE_LOCATION' directive specified for record #2.
+dkms.conf: Error! No 'BUILT_MODULE_NAME' directive specified for record #4.
+dkms.conf: Error! Directive 'DEST_MODULE_LOCATION' does not begin with
+'/kernel', '/updates', or '/extra' in record #4.
+
+Error! Bad conf file.
+File: ${abspwd}/test/dkms_conf_test_sparse_arrays/dkms.conf does not represent a valid dkms.conf file.
+EOF
+
+# --------------------------------------------------------------------------
+
 echo 'Testing dkms.conf with missing patch'
 run_with_expected_output dkms add test/dkms_conf_test_patch_missing << EOF
 Creating symlink /var/lib/dkms/dkms_conf_test/1.0/source -> /usr/src/dkms_conf_test-1.0

--- a/run_test.sh
+++ b/run_test.sh
@@ -2953,8 +2953,6 @@ dkms.conf: Error! Directive 'DEST_MODULE_LOCATION' does not begin with
 '/kernel', '/updates', or '/extra' in record #0.
 dkms.conf: Error! 'BUILT_MODULE_NAME' directive ends in '.o' or '.ko' in record #1.
 dkms.conf: Error! No 'DEST_MODULE_LOCATION' directive specified for record #1.
-dkms.conf: Error! Directive 'DEST_MODULE_LOCATION' does not begin with
-'/kernel', '/updates', or '/extra' in record #1.
 dkms.conf: Error! Unsupported AUTOINSTALL value 'maybe'
 
 Error! Bad conf file.

--- a/test/dkms_build_exclusive_test-1.0/dkms.conf
+++ b/test/dkms_build_exclusive_test-1.0/dkms.conf
@@ -1,5 +1,8 @@
 PACKAGE_NAME="dkms_build_exclusive_test"
 PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME[0]="dkms_build_exclusive_test"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
+BUILT_MODULE_NAME[1]="dkms_build_exclusive_test2"
+DEST_MODULE_LOCATION[1]="/updates/dkms"
 BUILD_EXCLUSIVE_ARCH="none"
 AUTOINSTALL="yes"

--- a/test/dkms_conf_test_sparse_arrays/dkms.conf
+++ b/test/dkms_conf_test_sparse_arrays/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="dkms_conf_test"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME[1]="dkms_sparse_arrays_test_1"
+DEST_MODULE_LOCATION[1]="/kernel/extra"
+BUILT_MODULE_NAME[3]="dkms_sparse_arrays_test_3"
+DEST_MODULE_LOCATION[3]="/kernel/extra"
+DEST_MODULE_LOCATION[4]="/oops"

--- a/test/dkms_per_module_config_exclusive_test-1.0/dkms.conf
+++ b/test/dkms_per_module_config_exclusive_test-1.0/dkms.conf
@@ -9,7 +9,7 @@ DEST_MODULE_LOCATION[1]="/updates/dkms"
 
 # Requires CONFIG_MODULES to be enabled and CONFIG_NONEXISTENT_CONFIG to be absent (should always match):
 BUILD_EXCLUSIVE_CONFIG[0]="CONFIG_MODULES !CONFIG_NONEXISTENT_CONFIG"
-# Requires CONFIG_NONEXISTENT_CONFIG to be enabled and CONFIG_MODULES to be abset (should never match):
+# Requires CONFIG_NONEXISTENT_CONFIG to be enabled and CONFIG_MODULES to be absent (should never match):
 BUILD_EXCLUSIVE_CONFIG[1]="!CONFIG_MODULES CONFIG_NONEXISTENT_CONFIG"
 
 AUTOINSTALL="yes"


### PR DESCRIPTION
properly support (or rather error out on) sparse module arrays
use cp --reflink=auto
revert dkms.service installation on Debian