### PR TITLE
Update tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test-distributions:
     name: Build in containers
+    continue-on-error: true
     strategy:
       matrix:
         distro:

--- a/run_test.sh
+++ b/run_test.sh
@@ -987,6 +987,8 @@ if [[ ! $only || $only = autoinstall ]]; then
 echo '*** Testing dkms autoinstall/kernel_{postinst/prerm}, dkms_autoinstaller'
 ############################################################################
 
+set_signing_message "dkms_test" "1.0"
+
 echo 'Testing without modules and without headers'
 
 echo ' Running dkms autoinstall'


### PR DESCRIPTION
1. When running tests with `./run_test.sh autoinstall`, the `SIGNING_MESSAGE` variable is not defined, as it's defined in an earlier section. Redefine it in the section.
2. Set `continue-on-error: true` in the Github workflow, so every test is run even if one specific distribution has failed. This makes it easier to spot errors.