### PR TITLE
Add BUILD_EXCLUSIVE directives support to single kernel modules (2nd take)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ redhat_kernel_install.d
 
 test_cmd_expected_output.log
 test_cmd_output.log
+*.code-workspace

--- a/dkms.8.in
+++ b/dkms.8.in
@@ -802,6 +802,19 @@ For example, if you set it as ="CONFIG_PCI !CONFIG_PREEMPT_RT", your module
 would only be built for kernels that have PCI enabled, but the RT patchset
 disabled.
 .TP
+.B BUILD_EXCLUSIVE_KERNEL[#]=, BUILD_EXCLUSIVE_KERNEL_MIN[#]=, BUILD_EXCLUSIVE_KERNEL_MAX[#]=, BUILD_EXCLUSIVE_ARCH[#]=, BUILD_EXCLUSIVE_CONFIG[#]=
+These optional per-module directives function identically to their global counterparts
+but apply only to the specific module at the given index. They allow you to specify
+different BUILD_EXCLUSIVE constraints for each module in a multi-module package.
+The global BUILD_EXCLUSIVE directives are still checked for backward compatibility,
+and if any module fails either the global or its specific per-module constraints,
+the build will be excluded.
+
+For example, if you have two modules in your package:
+.B BUILD_EXCLUSIVE_KERNEL[0]="^5\..*"
+.B BUILD_EXCLUSIVE_KERNEL[1]="^6\..*"
+Module 0 would only be built for kernel 5.x, while module 1 would only be built for kernel 6.x.
+.TP
 .B POST_ADD=
 The name of the script to be run after an
 .B add

--- a/dkms.in
+++ b/dkms.in
@@ -810,20 +810,81 @@ read_conf() {
     fi
     done
 
-    # Set build_exclude
-    [[ $obsolete_by && ! $BUILD_EXCLUSIVE_KERNEL_MAX ]] && BUILD_EXCLUSIVE_KERNEL_MAX=$obsolete_by
-    [[ $BUILD_EXCLUSIVE_KERNEL && ! $1 =~ $BUILD_EXCLUSIVE_KERNEL ]] && build_exclude="yes"
-    [[ $BUILD_EXCLUSIVE_KERNEL_MIN && "$(VER "$1")" < "$(VER "$BUILD_EXCLUSIVE_KERNEL_MIN")" ]] && build_exclude="yes"
-    [[ $BUILD_EXCLUSIVE_KERNEL_MAX && "$(VER "$1")" > "$(VER "$BUILD_EXCLUSIVE_KERNEL_MAX")" ]] && build_exclude="yes"
-    [[ $BUILD_EXCLUSIVE_ARCH && ! $2 =~ $BUILD_EXCLUSIVE_ARCH ]] && build_exclude="yes"
-    if [[ $BUILD_EXCLUSIVE_CONFIG && -e "${kernel_config}" ]]; then
-        local kconf
-        for kconf in $BUILD_EXCLUSIVE_CONFIG ; do
-            case "$kconf" in
-                !*) grep -q "^${kconf#!}=[ym]" "${kernel_config}" && build_exclude="yes" ;;
-                *)  grep -q "^${kconf}=[ym]" "${kernel_config}" || build_exclude="yes" ;;
-            esac
+    # Set build_exclude (preserve backward compatibility for OBSOLETE_BY)
+    # Only set global BUILD_EXCLUSIVE_KERNEL_MAX if obsolete_by is set and no global or per-module restrictions exist
+    if [[ $obsolete_by && ! $BUILD_EXCLUSIVE_KERNEL_MAX ]]; then
+        # Check if we have any per-module KERNEL_MAX restrictions
+        local has_per_module_max=false
+        for ((i=0; i < num_modules; i++)); do
+            [[ ${BUILD_EXCLUSIVE_KERNEL_MAX[i]} ]] && has_per_module_max=true && break
         done
+        # Only set global if no per-module restrictions exist (backward compatibility)
+        [[ $has_per_module_max == false ]] && BUILD_EXCLUSIVE_KERNEL_MAX=$obsolete_by
+    fi
+
+    # Function to check BUILD_EXCLUSIVE conditions for a specific module
+    check_build_exclusive_for_module() {
+        local module_index="$1"
+        local kernel_version="$2"
+        local arch="$3"
+
+        # Set has_build_exclusive_directives if any BUILD_EXCLUSIVE directives are defined
+        if [[ $BUILD_EXCLUSIVE_KERNEL || $BUILD_EXCLUSIVE_KERNEL_MIN || $BUILD_EXCLUSIVE_KERNEL_MAX || $BUILD_EXCLUSIVE_ARCH || $BUILD_EXCLUSIVE_CONFIG ]]; then
+            has_build_exclusive_directives=true
+        elif [[ ${BUILD_EXCLUSIVE_KERNEL[$module_index]} || ${BUILD_EXCLUSIVE_KERNEL_MIN[$module_index]} || ${BUILD_EXCLUSIVE_KERNEL_MAX[$module_index]} || ${BUILD_EXCLUSIVE_ARCH[$module_index]} || ${BUILD_EXCLUSIVE_CONFIG[$module_index]} ]]; then
+            has_build_exclusive_directives=true
+        fi
+
+        # Check global BUILD_EXCLUSIVE directives (backward compatibility)
+        [[ $BUILD_EXCLUSIVE_KERNEL && ! $kernel_version =~ $BUILD_EXCLUSIVE_KERNEL ]] && return 1
+        [[ $BUILD_EXCLUSIVE_KERNEL_MIN && "$(VER "$kernel_version")" < "$(VER "$BUILD_EXCLUSIVE_KERNEL_MIN")" ]] && return 1
+        [[ $BUILD_EXCLUSIVE_KERNEL_MAX && "$(VER "$kernel_version")" > "$(VER "$BUILD_EXCLUSIVE_KERNEL_MAX")" ]] && return 1
+        [[ $BUILD_EXCLUSIVE_ARCH && ! $arch =~ $BUILD_EXCLUSIVE_ARCH ]] && return 1
+
+        # Check per-module BUILD_EXCLUSIVE directives
+        [[ ${BUILD_EXCLUSIVE_KERNEL[$module_index]} && ! $kernel_version =~ ${BUILD_EXCLUSIVE_KERNEL[$module_index]} ]] && return 1
+        [[ ${BUILD_EXCLUSIVE_KERNEL_MIN[$module_index]} && "$(VER "$kernel_version")" < "$(VER "${BUILD_EXCLUSIVE_KERNEL_MIN[$module_index]}")" ]] && return 1
+        [[ ${BUILD_EXCLUSIVE_KERNEL_MAX[$module_index]} && "$(VER "$kernel_version")" > "$(VER "${BUILD_EXCLUSIVE_KERNEL_MAX[$module_index]}")" ]] && return 1
+        [[ ${BUILD_EXCLUSIVE_ARCH[$module_index]} && ! $arch =~ ${BUILD_EXCLUSIVE_ARCH[$module_index]} ]] && return 1
+
+        # Check BUILD_EXCLUSIVE_CONFIG (both global and per-module)
+        if [[ $BUILD_EXCLUSIVE_CONFIG && -e "${kernel_config}" ]]; then
+            local kconf
+            for kconf in $BUILD_EXCLUSIVE_CONFIG ; do
+                case "$kconf" in
+                    !*) grep -q "^${kconf#!}=[ym]" "${kernel_config}" && return 1 ;;
+                    *)  grep -q "^${kconf}=[ym]" "${kernel_config}" || return 1 ;;
+                esac
+            done
+        fi
+
+        if [[ ${BUILD_EXCLUSIVE_CONFIG[$module_index]} && -e "${kernel_config}" ]]; then
+            local kconf
+            for kconf in ${BUILD_EXCLUSIVE_CONFIG[$module_index]} ; do
+                case "$kconf" in
+                    !*) grep -q "^${kconf#!}=[ym]" "${kernel_config}" && return 1 ;;
+                    *)  grep -q "^${kconf}=[ym]" "${kernel_config}" || return 1 ;;
+                esac
+            done
+        fi
+
+        return 0
+    }
+
+    # Check if any module should be excluded from build
+    build_exclude=""
+    buildable_modules=0
+    has_build_exclusive_directives=false
+
+    for ((index=0; index < num_modules; index++)); do
+        if check_build_exclusive_for_module "$index" "$1" "$2"; then
+            ((buildable_modules++))
+        fi
+    done
+
+    # If no modules can be built and BUILD_EXCLUSIVE directives are defined, set build_exclude to fail the entire build
+    if [[ $buildable_modules -eq 0 && $has_build_exclusive_directives = true ]]; then
+        build_exclude="yes"
     fi
 
     # Helper function to check yes/no values
@@ -1350,8 +1411,8 @@ do_build()
     # Error out if build_exclude is set
     [[ $build_exclude ]] && diewarn 77 \
         "The $base_dir/dkms.conf"\
-        "for module $module/$module_version includes a BUILD_EXCLUSIVE directive"\
-        "which does not match this kernel/arch/config."\
+        "for module $module/$module_version includes BUILD_EXCLUSIVE directives"\
+        "which do not match this kernel/arch/config for any modules."\
         "This indicates that it should not be built."
 
     # Error out if source_tree is basically empty (binary-only dkms tarball w/ --force check)
@@ -1465,8 +1526,13 @@ do_build()
         report_build_problem 10 "Bad return status for module build on kernel: $kernelver ($arch)" \
         "Consult $build_log for more information."
 
-    # Make sure all the modules built successfully
+    # Make sure all the modules built successfully (skip excluded modules)
     for ((count=0; count < num_modules; count++)); do
+        # Skip modules that are excluded due to BUILD_EXCLUSIVE restrictions
+        if ! check_build_exclusive_for_module "$count" "$kernelver" "$arch"; then
+            continue
+        fi
+
         [[ -e ${built_module_location[$count]}${built_module_name[$count]}$module_uncompressed_suffix ]] && continue
         report_build_problem 7 \
             "Build of ${built_module_location[$count]}${built_module_name[$count]}$module_uncompressed_suffix failed for: $kernelver ($arch)" \
@@ -1485,6 +1551,11 @@ do_build()
         CP -f "$build_dir/Module.symvers" "$tmp_base_dir/module/Module.symvers"
     fi
     for ((count=0; count < num_modules; count++)); do
+        # Skip modules that are excluded due to BUILD_EXCLUSIVE restrictions
+        if ! check_build_exclusive_for_module "$count" "$kernelver" "$arch"; then
+            continue
+        fi
+
         local the_module
         local built_module
         local compressed_module
@@ -1530,8 +1601,13 @@ do_build()
         fi
     done
 
-    # Validate build completeness
+    # Validate build completeness (skip excluded modules)
     for ((index=0; index < num_modules; index++)); do
+        # Skip modules that are excluded due to BUILD_EXCLUSIVE restrictions
+        if ! check_build_exclusive_for_module "$index" "$kernelver" "$arch"; then
+            continue
+        fi
+
         local m
         local f
         m=${dest_module_name[index]}
@@ -1648,8 +1724,13 @@ do_install()
     set_module_suffix "$kernelver"
     read_conf_strict_or_die "$kernelver" "$arch"
 
-    # Validate build completeness
+    # Validate build completeness (skip excluded modules)
     for ((index=0; index < num_modules; index++)); do
+        # Skip modules that are excluded due to BUILD_EXCLUSIVE restrictions
+        if ! check_build_exclusive_for_module "$index" "$kernelver" "$arch"; then
+            continue
+        fi
+
         local m
         local f
         m=${dest_module_name[index]}
@@ -1676,6 +1757,11 @@ do_install()
     fi
 
     for ((count=0; count < num_modules; count++)); do
+        # Skip modules that are excluded due to BUILD_EXCLUSIVE restrictions
+        if ! check_build_exclusive_for_module "$count" "$kernelver" "$arch"; then
+            continue
+        fi
+
         # Check this version against what is already in the kernel
         check_version_sanity "$kernelver" "$arch" "$obsolete_by" "${dest_module_name[$count]}" || continue
 
@@ -2072,8 +2158,45 @@ maybe_unbuild_module()
 maybe_uninstall_module()
 {
     is_module_installed "$module" "$module_version" "$1" "$2" || {
-        echo "Module $module/$module_version is not installed for kernel $1 ($2)."\
-            "Skipping..."
+        # Check if this module might have been excluded due to BUILD_EXCLUSIVE restrictions
+        # If so, don't show the "not installed" message since it's expected
+        local was_excluded=false
+
+        # Try to read the dkms.conf to check BUILD_EXCLUSIVE settings
+        if [[ -f "$dkms_tree/$module/$module_version/source/dkms.conf" ]]; then
+            # Temporarily read the conf to check BUILD_EXCLUSIVE settings
+            local saved_last_mvka="$last_mvka"
+            local saved_last_mvka_conf="$last_mvka_conf"
+            local saved_num_modules="$num_modules"
+
+            # Read conf without modifying global state permanently
+            read_conf "$1" "$2" "$dkms_tree/$module/$module_version/source/dkms.conf" 2>/dev/null || true
+
+            # If this package has any BUILD_EXCLUSIVE restrictions, suppress the message
+            # because it can be confusing to users (modules might be built but not installed)
+            local has_build_exclusive=false
+            for ((index=0; index < num_modules; index++)); do
+                if [[ ${BUILD_EXCLUSIVE_KERNEL[index]} || ${BUILD_EXCLUSIVE_KERNEL_MIN[index]} || ${BUILD_EXCLUSIVE_KERNEL_MAX[index]} || ${BUILD_EXCLUSIVE_ARCH[index]} || ${BUILD_EXCLUSIVE_CONFIG[index]} ]]; then
+                    has_build_exclusive=true
+                    break
+                fi
+            done
+
+            if [[ $has_build_exclusive == true ]]; then
+                was_excluded=true
+            fi
+
+            # Restore global state
+            last_mvka="$saved_last_mvka"
+            last_mvka_conf="$saved_last_mvka_conf"
+            num_modules="$saved_num_modules"
+        fi
+
+        # Only show the "not installed" message if it wasn't excluded due to BUILD_EXCLUSIVE
+        if [[ $was_excluded == false ]]; then
+            echo "Module $module/$module_version is not installed for kernel $1 ($2)."\
+                "Skipping..."
+        fi
         return 0
     }
     do_uninstall "$1" "$2"
@@ -2252,6 +2375,11 @@ module_status_built_extra() (
     read_conf "$3" "$4" "$dkms_tree/$1/$2/source/dkms.conf"
     [[ -d $dkms_tree/$1/original_module/$3/$4 ]] && echo -n " (Original modules exist)"
     for ((count=0; count < num_modules; count++)); do
+        # Skip modules that are excluded due to BUILD_EXCLUSIVE restrictions
+        if ! check_build_exclusive_for_module "$count" "$3" "$4"; then
+            continue
+        fi
+
         tree_mod=$(compressed_or_uncompressed "$dkms_tree/$1/$2/$3/$4/module" "${dest_module_name[$count]}")
         if [[ ! $tree_mod ]]; then
             echo -n " (Built modules are missing in the kernel modules folder)"

--- a/run_test.sh
+++ b/run_test.sh
@@ -52,6 +52,9 @@ TEST_MODULES=(
     "dkms_deprecated_test"
     "dkms_build_exclusive_test"
     "dkms_build_exclusive_dependencies_test"
+    "dkms_per_module_config_test"
+    "dkms_per_module_kernel_version_test"
+    "dkms_per_module_config_exclusive_test"
 )
 TEST_TMPDIRS=(
     "${tmpdir}/dkms_test_dir_${KERNEL_VER}/"
@@ -2615,8 +2618,8 @@ run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
-for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
-which does not match this kernel/arch/config.
+for module dkms_build_exclusive_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_noisy_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
@@ -2698,8 +2701,8 @@ run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
-for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
-which does not match this kernel/arch/config.
+for module dkms_build_exclusive_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
 This indicates that it should not be built.
 
 Autoinstall on ${KERNEL_VER} succeeded for module(s) dkms_dependencies_test dkms_noisy_test dkms_patches_test dkms_scripts_test dkms_test.
@@ -2853,7 +2856,6 @@ EOF
 
 echo 'Removing the build-exclusive test module'
 run_with_expected_output dkms remove -k "${KERNEL_VER}" -m dkms_build_exclusive_test -v 1.0 << EOF
-Module dkms_build_exclusive_test/1.0 is not installed for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
 Module dkms_build_exclusive_test/1.0 is not built for kernel ${KERNEL_VER} (${KERNEL_ARCH}). Skipping...
 
 Deleting module dkms_build_exclusive_test/1.0 completely from the DKMS tree.
@@ -3686,8 +3688,8 @@ EOF
 echo '(Not) building the build-exclusive test module'
 run_with_expected_error 77 dkms build -k "${KERNEL_VER}" -m dkms_build_exclusive_test -v 1.0 << EOF
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
-for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
-which does not match this kernel/arch/config.
+for module dkms_build_exclusive_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
 This indicates that it should not be built.
 EOF
 run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
@@ -3699,8 +3701,8 @@ run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
-for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
-which does not match this kernel/arch/config.
+for module dkms_build_exclusive_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
 This indicates that it should not be built.
 
 Autoinstall on ${KERNEL_VER} was skipped for module(s) dkms_build_exclusive_test.
@@ -3723,8 +3725,8 @@ run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
-for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
-which does not match this kernel/arch/config.
+for module dkms_build_exclusive_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
@@ -3764,8 +3766,8 @@ run_with_expected_error 11 dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
-for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
-which does not match this kernel/arch/config.
+for module dkms_build_exclusive_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_failing_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
@@ -3827,14 +3829,14 @@ run_with_expected_output dkms autoinstall -k "${KERNEL_VER}" << EOF
 ${SIGNING_PROLOGUE}
 Autoinstall of module dkms_build_exclusive_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
-for module dkms_build_exclusive_test/1.0 includes a BUILD_EXCLUSIVE directive
-which does not match this kernel/arch/config.
+for module dkms_build_exclusive_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
 This indicates that it should not be built.
 
 Autoinstall of module dkms_build_exclusive_dependencies_test/1.0 for kernel ${KERNEL_VER} (${KERNEL_ARCH})
 Warning: The /var/lib/dkms/dkms_build_exclusive_dependencies_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
-for module dkms_build_exclusive_dependencies_test/1.0 includes a BUILD_EXCLUSIVE directive
-which does not match this kernel/arch/config.
+for module dkms_build_exclusive_dependencies_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
 This indicates that it should not be built.
 
 Autoinstall on ${KERNEL_VER} was skipped for module(s) dkms_build_exclusive_test dkms_build_exclusive_dependencies_test.
@@ -3863,6 +3865,94 @@ run_status_with_expected_output 'dkms_build_exclusive_test' << EOF
 EOF
 
 remove_module_source_tree /usr/src/dkms_build_exclusive_test-1.0
+
+############################################################################
+echo '*** Testing per-module BUILD_EXCLUSIVE directives'
+############################################################################
+
+echo 'Adding per-module config test module'
+run_with_expected_output dkms add test/dkms_per_module_config_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_per_module_config_test/1.0/source -> /usr/src/dkms_per_module_config_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_per_module_config_test-1.0
+run_status_with_expected_output 'dkms_per_module_config_test' << EOF
+dkms_per_module_config_test/1.0: added
+EOF
+
+echo 'Testing per-module config test module build (should be excluded due to per-module restrictions)'
+run_with_expected_error 77 dkms build -k "${KERNEL_VER}" -m dkms_per_module_config_test -v 1.0 << EOF
+Warning: The /var/lib/dkms/dkms_per_module_config_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+for module dkms_per_module_config_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
+This indicates that it should not be built.
+EOF
+run_status_with_expected_output 'dkms_per_module_config_test' << EOF
+dkms_per_module_config_test/1.0: added
+EOF
+
+echo 'Removing per-module config test module'
+run_with_expected_output dkms remove --all -m dkms_per_module_config_test -v 1.0 << EOF
+Deleting module dkms_per_module_config_test/1.0 completely from the DKMS tree.
+EOF
+run_status_with_expected_output 'dkms_per_module_config_test' << EOF
+EOF
+remove_module_source_tree /usr/src/dkms_per_module_config_test-1.0
+
+echo 'Adding per-module kernel version test module'
+run_with_expected_output dkms add test/dkms_per_module_kernel_version_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_per_module_kernel_version_test/1.0/source -> /usr/src/dkms_per_module_kernel_version_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_per_module_kernel_version_test-1.0
+run_status_with_expected_output 'dkms_per_module_kernel_version_test' << EOF
+dkms_per_module_kernel_version_test/1.0: added
+EOF
+
+echo 'Testing per-module kernel version test module build (should be excluded due to kernel version restrictions)'
+run_with_expected_error 77 dkms build -k "${KERNEL_VER}" -m dkms_per_module_kernel_version_test -v 1.0 << EOF
+Warning: The /var/lib/dkms/dkms_per_module_kernel_version_test/1.0/${KERNEL_VER}/${KERNEL_ARCH}/dkms.conf
+for module dkms_per_module_kernel_version_test/1.0 includes BUILD_EXCLUSIVE directives
+which do not match this kernel/arch/config for any modules.
+This indicates that it should not be built.
+EOF
+run_status_with_expected_output 'dkms_per_module_kernel_version_test' << EOF
+dkms_per_module_kernel_version_test/1.0: added
+EOF
+
+echo 'Removing per-module kernel version test module'
+run_with_expected_output dkms remove --all -m dkms_per_module_kernel_version_test -v 1.0 << EOF
+Deleting module dkms_per_module_kernel_version_test/1.0 completely from the DKMS tree.
+EOF
+run_status_with_expected_output 'dkms_per_module_kernel_version_test' << EOF
+EOF
+remove_module_source_tree /usr/src/dkms_per_module_kernel_version_test-1.0
+
+echo 'Adding per-module config exclusive test module'
+run_with_expected_output dkms add test/dkms_per_module_config_exclusive_test-1.0 << EOF
+Creating symlink /var/lib/dkms/dkms_per_module_config_exclusive_test/1.0/source -> /usr/src/dkms_per_module_config_exclusive_test-1.0
+EOF
+check_module_source_tree_created /usr/src/dkms_per_module_config_exclusive_test-1.0
+run_status_with_expected_output 'dkms_per_module_config_exclusive_test' << EOF
+dkms_per_module_config_exclusive_test/1.0: added
+EOF
+
+echo 'Testing per-module config exclusive test module build (one should be built, one not)'
+run_with_expected_output dkms build -k "${KERNEL_VER}" -m dkms_per_module_config_exclusive_test -v 1.0 << EOF
+${SIGNING_PROLOGUE}
+Building module(s)... done.
+Signing module /var/lib/dkms/dkms_per_module_config_exclusive_test/1.0/build/dkms_per_module_config_exclusive_test_mod1.ko
+EOF
+run_status_with_expected_output 'dkms_per_module_config_exclusive_test' << EOF
+dkms_per_module_config_exclusive_test/1.0, ${KERNEL_VER}, ${KERNEL_ARCH}: built
+EOF
+
+echo 'Removing per-module config exclusive test module'
+run_with_expected_output dkms remove --all -m dkms_per_module_config_exclusive_test -v 1.0 << EOF
+
+Deleting module dkms_per_module_config_exclusive_test/1.0 completely from the DKMS tree.
+EOF
+run_status_with_expected_output 'dkms_per_module_config_exclusive_test' << EOF
+EOF
+remove_module_source_tree /usr/src/dkms_per_module_config_exclusive_test-1.0
 
 echo 'Checking that the environment is clean again'
 check_no_dkms_test

--- a/test/dkms_per_module_config_exclusive_test-1.0/Makefile
+++ b/test/dkms_per_module_config_exclusive_test-1.0/Makefile
@@ -1,0 +1,1 @@
+obj-m += dkms_per_module_config_exclusive_test_mod1.o dkms_per_module_config_exclusive_test_mod2.o

--- a/test/dkms_per_module_config_exclusive_test-1.0/dkms.conf
+++ b/test/dkms_per_module_config_exclusive_test-1.0/dkms.conf
@@ -1,0 +1,15 @@
+PACKAGE_NAME="dkms_per_module_config_exclusive_test"
+PACKAGE_VERSION="1.0"
+
+BUILT_MODULE_NAME[0]="dkms_per_module_config_exclusive_test_mod1"
+BUILT_MODULE_NAME[1]="dkms_per_module_config_exclusive_test_mod2"
+
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+DEST_MODULE_LOCATION[1]="/updates/dkms"
+
+# Requires CONFIG_MODULES to be enabled and CONFIG_NONEXISTENT_CONFIG to be absent (should always match):
+BUILD_EXCLUSIVE_CONFIG[0]="CONFIG_MODULES !CONFIG_NONEXISTENT_CONFIG"
+# Requires CONFIG_NONEXISTENT_CONFIG to be enabled and CONFIG_MODULES to be absent (should never match):
+BUILD_EXCLUSIVE_CONFIG[1]="!CONFIG_MODULES CONFIG_NONEXISTENT_CONFIG"
+
+AUTOINSTALL="yes"

--- a/test/dkms_per_module_config_exclusive_test-1.0/dkms_per_module_config_exclusive_test_mod1.c
+++ b/test/dkms_per_module_config_exclusive_test-1.0/dkms_per_module_config_exclusive_test_mod1.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_exclusive_test_mod1_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_exclusive_test_mod1: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_exclusive_test_mod1_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_exclusive_test_mod1: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_exclusive_test_mod1_init);
+module_exit(dkms_per_module_config_exclusive_test_mod1_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config exclusive test module 1");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_config_exclusive_test-1.0/dkms_per_module_config_exclusive_test_mod2.c
+++ b/test/dkms_per_module_config_exclusive_test-1.0/dkms_per_module_config_exclusive_test_mod2.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_exclusive_test_mod2_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_exclusive_test_mod2: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_exclusive_test_mod2_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_exclusive_test_mod2: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_exclusive_test_mod2_init);
+module_exit(dkms_per_module_config_exclusive_test_mod2_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config exclusive test module 2");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_config_test-1.0/Makefile
+++ b/test/dkms_per_module_config_test-1.0/Makefile
@@ -1,0 +1,1 @@
+obj-m += dkms_per_module_config_test_mod1.o dkms_per_module_config_test_mod2.o dkms_per_module_config_test_mod3.o

--- a/test/dkms_per_module_config_test-1.0/dkms.conf
+++ b/test/dkms_per_module_config_test-1.0/dkms.conf
@@ -1,0 +1,18 @@
+PACKAGE_NAME="dkms_per_module_config_test"
+PACKAGE_VERSION="1.0"
+
+BUILT_MODULE_NAME[0]="dkms_per_module_config_test_mod1"
+BUILT_MODULE_NAME[1]="dkms_per_module_config_test_mod2"
+BUILT_MODULE_NAME[2]="dkms_per_module_config_test_mod3"
+
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+DEST_MODULE_LOCATION[1]="/updates/dkms"
+DEST_MODULE_LOCATION[2]="/updates/dkms"
+
+# Build only for kernel starting with 99 (should never match):
+BUILD_EXCLUSIVE_KERNEL[0]="^99\..*"
+# Build for any kernel (should always match) but only for architecture "none" (should never match):
+BUILD_EXCLUSIVE_KERNEL[1]=".*"
+BUILD_EXCLUSIVE_ARCH[1]="none"
+
+AUTOINSTALL="yes"

--- a/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod1.c
+++ b/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod1.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_test_mod1_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod1: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_test_mod1_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod1: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_test_mod1_init);
+module_exit(dkms_per_module_config_test_mod1_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config test module 1");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod2.c
+++ b/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod2.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_test_mod2_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod2: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_test_mod2_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod2: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_test_mod2_init);
+module_exit(dkms_per_module_config_test_mod2_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config test module 2");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod3.c
+++ b/test/dkms_per_module_config_test-1.0/dkms_per_module_config_test_mod3.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_config_test_mod3_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod3: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_config_test_mod3_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_config_test_mod3: module unloaded\n");
+}
+
+module_init(dkms_per_module_config_test_mod3_init);
+module_exit(dkms_per_module_config_test_mod3_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module config test module 3");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_kernel_version_test-1.0/Makefile
+++ b/test/dkms_per_module_kernel_version_test-1.0/Makefile
@@ -1,0 +1,1 @@
+obj-m += dkms_per_module_kernel_version_test_old.o dkms_per_module_kernel_version_test_new.o

--- a/test/dkms_per_module_kernel_version_test-1.0/dkms.conf
+++ b/test/dkms_per_module_kernel_version_test-1.0/dkms.conf
@@ -1,0 +1,15 @@
+PACKAGE_NAME="dkms_per_module_kernel_version_test"
+PACKAGE_VERSION="1.0"
+
+BUILT_MODULE_NAME[0]="dkms_per_module_kernel_version_test_old"
+BUILT_MODULE_NAME[1]="dkms_per_module_kernel_version_test_new"
+
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+DEST_MODULE_LOCATION[1]="/updates/dkms"
+
+# Build only for kernels < 4.0 (should never match):
+BUILD_EXCLUSIVE_KERNEL_MAX[0]="3.99"
+# Build only for kernels >= 5.0 (should always match):
+BUILD_EXCLUSIVE_KERNEL_MIN[1]="5.0"
+
+AUTOINSTALL="yes"

--- a/test/dkms_per_module_kernel_version_test-1.0/dkms_per_module_kernel_version_test_new.c
+++ b/test/dkms_per_module_kernel_version_test-1.0/dkms_per_module_kernel_version_test_new.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_kernel_version_test_new_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_kernel_version_test_new: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_kernel_version_test_new_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_kernel_version_test_new: module unloaded\n");
+}
+
+module_init(dkms_per_module_kernel_version_test_new_init);
+module_exit(dkms_per_module_kernel_version_test_new_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module kernel version test - new kernel module");
+MODULE_VERSION("1.0");

--- a/test/dkms_per_module_kernel_version_test-1.0/dkms_per_module_kernel_version_test_old.c
+++ b/test/dkms_per_module_kernel_version_test-1.0/dkms_per_module_kernel_version_test_old.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+static int __init dkms_per_module_kernel_version_test_old_init(void)
+{
+    printk(KERN_INFO "dkms_per_module_kernel_version_test_old: module loaded\n");
+    return 0;
+}
+
+static void __exit dkms_per_module_kernel_version_test_old_exit(void)
+{
+    printk(KERN_INFO "dkms_per_module_kernel_version_test_old: module unloaded\n");
+}
+
+module_init(dkms_per_module_kernel_version_test_old_init);
+module_exit(dkms_per_module_kernel_version_test_old_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("DKMS per-module kernel version test - old kernel module");
+MODULE_VERSION("1.0");


### PR DESCRIPTION
Add per-module `BUILD_EXCLUSIVE_*` directives in DKMS.

* Backward compatibility: global `BUILD_EXCLUSIVE` directives still work as before.
* Per-module support: new array-based directives `BUILD_EXCLUSIVE_KERNEL[#]`, `BUILD_EXCLUSIVE_KERNEL_MIN[#]`, `BUILD_EXCLUSIVE_KERNEL_MAX[#]`, `BUILD_EXCLUSIVE_ARCH[#]`, and `BUILD_EXCLUSIVE_CONFIG[#]`.
* Combined logic: both global and per-module directives are checked, and if any module fails either set of constraints, the build is excluded.

Re-implements https://github.com/dell/dkms/issues/471.